### PR TITLE
Bump the iOS package.

### DIFF
--- a/Directory.iOS.targets
+++ b/Directory.iOS.targets
@@ -1,11 +1,9 @@
 <Project>
 
-  <Target Name="SetiOSDefaultPublishProps" BeforeTargets="PrepareForPublish">
-    <PropertyGroup>
-      <PublishTrimmed>True</PublishTrimmed>
-      <MonoAOT>True</MonoAOT>
-      <UseAppHost>False</UseAppHost>
-    </PropertyGroup>
-  </Target>
+  <PropertyGroup Condition="'$(_PlatformName)' == 'iOS'">
+    <PublishTrimmed>True</PublishTrimmed>
+    <MonoAOT>True</MonoAOT>
+    <UseAppHost>False</UseAppHost>
+  </PropertyGroup>
 
 </Project>

--- a/HelloForms.iOS/HelloForms.iOS.csproj
+++ b/HelloForms.iOS/HelloForms.iOS.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp5.0</TargetFramework>
-    <RuntimeIdentifier>ios.13-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" GeneratePathProperty="true" />

--- a/HelloiOS/AppDelegate.cs
+++ b/HelloiOS/AppDelegate.cs
@@ -20,7 +20,9 @@ namespace HelloiOS
         {
             // create a new window instance based on the screen size
             Window = new UIWindow(UIScreen.MainScreen.Bounds);
-            Window.RootViewController = new UIViewController();
+            var vc = new UIViewController ();
+            vc.View.BackgroundColor = UIColor.Green;
+            Window.RootViewController = vc;
 
             // make the window visible
             Window.MakeKeyAndVisible();

--- a/HelloiOS/HelloiOS.csproj
+++ b/HelloiOS/HelloiOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp5.0</TargetFramework>
-    <RuntimeIdentifier>ios.13-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ _This can also be done at the same time as `-t:Install`._
 
 To build the iOS project:
 
-    dotnet publish HelloiOS/HelloiOS.csproj --self-contained
+    dotnet publish HelloiOS/HelloiOS.csproj
 
-_NOTE: eventually `--self-contained` won't be needed on iOS._
+To launch the iOS project on a simulator:
+
+    dotnet publish HelloiOS/HelloiOS.csproj -t:Run
 
 [0]: https://github.com/dotnet/installer#installers-and-binaries
 
@@ -49,6 +51,7 @@ Currently...
 * There is not a way to setup a Xamarin.Android binding project.
 * `System.Console.WriteLine` does not work. Use
   `Android.Util.Log.Debug` or p/invoke [NSLog][nslog] for now.
+* Building for device doesn't work for iOS.
 
 [nslog]: https://stackoverflow.com/questions/9204160/monotouch-nslog-and-testflightsdk
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "msbuild-sdks": {
-            "Microsoft.iOS.Sdk": "13.21.1-alpha.17",
+            "Microsoft.iOS.Sdk": "13.21.1-alpha.85",
             "Microsoft.Android.Sdk": "10.4.99.37"
     }
 }


### PR DESCRIPTION
* Set iOS-specific overrides for PublishedTrimmmed, MonoAOT and UseAppHost
  earlier, because some of the targets that use them need them to be set at
  property group evalation time.

* Make the simulator (x84) the default RID.

* Make sure to set OutputType=Exe.

* Make the HelloiOS show a green background (as opposed to a black background
  that might mean the app deadlocked on startup).

* Update the README with instructions how to run iOS apps in the simulator.

	* Remove --self-contained, things work without it.