### PR TITLE
Bump Xamarin SDKs

### DIFF
--- a/Directory.Android.targets
+++ b/Directory.Android.targets
@@ -1,24 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <AssetTargetFallback>monoandroid10.0;monoandroid90;monoandroid81;monoandroid80;$(AssetTargetFallback)</AssetTargetFallback>
     <!-- Workaround to skip a .NET 4.5 MSBuild task: https://github.com/xamarin/AndroidSupportComponents/blob/68d28bc676673ec45f7f5ea2462c10bed87e2a2a/source/buildtasks/support-vector-drawable/Support-Vector-Drawable-BuildTasks.csproj#L10 -->
     <VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
   </PropertyGroup>
-
-  <!-- NOTE: the target below is workarounds for $(AssetTargetFallback) usage -->
-  <!-- related: https://github.com/NuGet/docs.microsoft.com-nuget/issues/1955 -->
-  <Target
-    Name="FixAndroidNuGetAssemblies"
-    AfterTargets="ResolvePackageAssets"
-    Condition="'$(PkgXamarin_Forms)' != ''">
-    <ItemGroup>
-      <Reference Include="Xamarin.Forms.Platform"         HintPath="$(PkgXamarin_Forms)\lib\MonoAndroid10.0\Xamarin.Forms.Platform.dll" />
-      <Reference Include="Xamarin.Forms.Platform.Android" HintPath="$(PkgXamarin_Forms)\lib\MonoAndroid10.0\Xamarin.Forms.Platform.Android.dll" />
-      <Reference Include="FormsViewGroup"                 HintPath="$(PkgXamarin_Forms)\lib\MonoAndroid10.0\FormsViewGroup.dll" />
-      <RuntimeCopyLocalItems          Remove="$(PkgXamarin_Forms)\lib\netstandard2.0\Xamarin.Forms.Platform.dll" />
-      <ResolvedCompileFileDefinitions Remove="$(PkgXamarin_Forms)\lib\netstandard2.0\Xamarin.Forms.Platform.dll" />
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/HelloAndroid/HelloAndroid.csproj
+++ b/HelloAndroid/HelloAndroid.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Android.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>android.21-x86</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/HelloForms.Android/HelloForms.Android.csproj
+++ b/HelloForms.Android/HelloForms.Android.csproj
@@ -1,50 +1,12 @@
 <Project Sdk="Microsoft.Android.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>android.21-x86</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" GeneratePathProperty="true" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
     <ProjectReference Include="..\HelloForms\HelloForms.csproj" />
-    <!-- NOTE: the items below are workarounds for $(AssetTargetFallback) usage -->
-    <!-- see: https://github.com/NuGet/docs.microsoft.com-nuget/issues/1955 -->
-    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.Annotation" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat.Resources" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.Arch.Core.Common" Version="2.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.Arch.Core.Runtime" Version="2.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.AsyncLayoutInflater" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.2.0" />
-    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.CoordinatorLayout" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.2.0" />
-    <PackageReference Include="Xamarin.AndroidX.CursorAdapter" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.CustomView" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.DocumentFile" Version="1.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.DrawerLayout" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.2.3" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.Core.UI" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.Core.Utils" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.2.0" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.2.0" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.2.0" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.2.0" />
-    <PackageReference Include="Xamarin.AndroidX.Loader" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.Print" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.SavedState" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.SlidingPaneLayout" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.0.0" />
-    <PackageReference Include="Xamarin.AndroidX.Transition" Version="1.3.1" />
-    <PackageReference Include="Xamarin.AndroidX.VectorDrawable" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.VectorDrawable.Animated" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.VersionedParcelable" Version="1.1.0" />
-    <PackageReference Include="Xamarin.AndroidX.ViewPager" Version="1.0.0" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.0.0" />
     <!--
       add few more packages to bring missing dependencies while linking
       it is probably same issue as here: https://github.com/mono/linker/issues/1139
@@ -56,6 +18,5 @@
     <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.3.20214.6" />
     <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.3.20214.6" />
     <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.3.20214.6" />
-    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" Version="1.0.0.2" />
   </ItemGroup>
 </Project>

--- a/HelloForms.iOS/HelloForms.iOS.csproj
+++ b/HelloForms.iOS/HelloForms.iOS.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/HelloiOS/HelloiOS.csproj
+++ b/HelloiOS/HelloiOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ Prerequisites:
 
 For example, to build the Android project:
 
-    dotnet publish HelloAndroid/HelloAndroid.csproj
+    dotnet build HelloAndroid/HelloAndroid.csproj
 
 You can launch the Android project to an attached emulator via:
 
-    dotnet publish HelloAndroid/HelloAndroid.csproj -t:Run
+    dotnet build HelloAndroid/HelloAndroid.csproj -t:Run
 
 To deploy and run on a device, you can either modify `$(RuntimeIdentifier)` in
 the `.csproj` or run:
 
-    dotnet publish HelloAndroid/HelloAndroid.csproj -t:Run -r android.21-arm64
+    dotnet build HelloAndroid/HelloAndroid.csproj -t:Run -r android.21-arm64
 
 ## iOS
 
@@ -37,11 +37,11 @@ Prerequisites:
 
 To build the iOS project:
 
-    dotnet publish HelloiOS/HelloiOS.csproj
+    dotnet build HelloiOS/HelloiOS.csproj
 
 To launch the iOS project on a simulator:
 
-    dotnet publish HelloiOS/HelloiOS.csproj -t:Run
+    dotnet build HelloiOS/HelloiOS.csproj -t:Run
 
 [0]: https://github.com/dotnet/installer#installers-and-binaries
 
@@ -63,11 +63,10 @@ These are notes for things we had to workaround for these samples to work.
 ### NuGet
 
 Currently, NuGet is not able to restore existing Xamarin.Android/iOS
-packages for a .NET 6 project. We used `$(AssetTargetFallback)`,
+packages for a .NET 6 project. We tried `$(AssetTargetFallback)`,
 however, this option does not work in combination with transitive
 dependencies. The `Xamarin.AndroidX.*` set of NuGet packages has a
-complex dependency tree. We just listed every package manually for
-now.
+complex dependency tree.
 
 Additionally, we had some problems with the Xamarin.Forms NuGet
 package listing the same assembly in both:
@@ -75,9 +74,8 @@ package listing the same assembly in both:
 * `lib\netstandard2.0\Xamarin.Forms.Platform.dll`
 * `lib\MonoAndroid10.0\Xamarin.Forms.Platform.dll`
 
-For now we added an MSBuild target in `Directory.Build.targets` to
-resolve this. We also had to manually reference
-`Xamarin.Forms.Platform.Android.dll`.
+For now we added workarounds in `xamarin-android`, see
+[xamarin-android#4663](https://github.com/xamarin/xamarin-android/pull/4663).
 
 ### AndroidX MSBuild tasks
 
@@ -88,6 +86,9 @@ We set `$(VectorDrawableCheckBuildToolsVersionTaskBeforeTargets)` to
 an empty string in `Directory.Build.targets` for now.
 
 [1]: https://github.com/xamarin/AndroidSupportComponents/blob/68d28bc676673ec45f7f5ea2462c10bed87e2a2a/source/buildtasks/support-vector-drawable/Support-Vector-Drawable-BuildTasks.csproj#L10
+
+Eventually, we can use a newer version of Xamarin.AndroidX.VectorDrawable
+with [AndroidX#103](https://github.com/xamarin/AndroidX/pull/103).
 
 ## Contributing
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,34 +4,77 @@ trigger:
 - master
 
 variables:
-  DotNetVersion: 5.0.100-preview.4.20227.14
+  DotNetVersion: 5.0.100-preview.6.20265.2
 
 jobs:
 - job: windows
   pool:
     name: Hosted Windows 2019 with VS2019
+  variables:
+    LogDirectory: $(Build.ArtifactStagingDirectory)\logs
   steps:
     - powershell: |
-        $ErrorActionPreference = 'Stop'
         $ProgressPreference = 'SilentlyContinue'
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
         & .\dotnet-install.ps1 -Version $(DotNetVersion) -InstallDir "$env:ProgramFiles\dotnet\" -Verbose
         & dotnet --list-sdks
       displayName: install .NET $(DotNetVersion)
-    - script: |
-        dotnet publish HelloAndroid\HelloAndroid.csproj -c Debug
-        dotnet publish HelloAndroid\HelloAndroid.csproj -c Release
-        dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Debug
-        dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Release
+      errorActionPreference: stop
+
+    - powershell: |
+        & dotnet build HelloAndroid\HelloAndroid.csproj -c Debug -bl:$(LogDirectory)\Debug-HelloAndroid.binlog
+        & dotnet build HelloAndroid\HelloAndroid.csproj -c Release -bl:$(LogDirectory)\Release-HelloAndroid.binlog
+        & dotnet build HelloForms.Android\HelloForms.Android.csproj -c Debug -bl:$(LogDirectory)\Debug-HelloForms.binlog
+        & dotnet build HelloForms.Android\HelloForms.Android.csproj -c Release -bl:$(LogDirectory)\Release-HelloForms.binlog
+      displayName: build samples
+      errorActionPreference: stop
+
+    - task: CopyFiles@2
+      displayName: copy artifacts
+      inputs:
+        contents: '*Android\**\*-Signed.apk'
+        targetFolder: $(Build.ArtifactStagingDirectory)
+        overWrite: true
+      condition: always()
+
+    - task: PublishPipelineArtifact@1
+      displayName: publish artifacts
+      inputs:
+        artifactName: windows-artifacts
+        targetPath: $(Build.ArtifactStagingDirectory)
+      condition: always()
+
 - job: mac
   pool:
     name: Hosted macOS
+  variables:
+    LogDirectory: $(Build.ArtifactStagingDirectory)/logs
   steps:
-    - bash: |
-        curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
-        sh dotnet-install.sh --version $(DotNetVersion) --install-dir ~/.dotnet/ --verbose
+    - bash: >
+        curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh &&
+        sh dotnet-install.sh --version $(DotNetVersion) --install-dir ~/.dotnet/ --verbose &&
         dotnet --list-sdks
       displayName: install .NET $(DotNetVersion)
-    - script: |
-        dotnet publish net5-samples.sln -c Debug
-        dotnet publish net5-samples.sln -c Release
+
+    - bash: |
+        # Re-enable if Xcode 11.4.1 available or issue fixed: https://github.com/xamarin/xamarin-macios/issues/8325
+        # dotnet build net5-samples.sln -c Debug -bl:$(LogDirectory)/Debug.binlog &&
+        dotnet build net5-samples.sln -c Release -bl:$(LogDirectory)/Release.binlog
+      displayName: build samples
+
+    - task: CopyFiles@2
+      displayName: copy artifacts
+      inputs:
+        contents: |
+          *Android/**/*-Signed.apk
+          *iOS/**/*.app/**
+        targetFolder: $(Build.ArtifactStagingDirectory)
+        overWrite: true
+      condition: always()
+
+    - task: PublishPipelineArtifact@1
+      displayName: publish artifacts
+      inputs:
+        artifactName: mac-artifacts
+        targetPath: $(Build.ArtifactStagingDirectory)
+      condition: always()

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "msbuild-sdks": {
-            "Microsoft.iOS.Sdk": "13.4.100-ci.net5-preview-net5build.4",
-            "Microsoft.Android.Sdk": "10.4.99.51"
+            "Microsoft.iOS.Sdk": "13.5.100-ci.net5-preview-net5build.481",
+            "Microsoft.Android.Sdk": "10.0.100-ci.master.61"
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/net5-samples/issues/16

`$(TargetFramework)` should be `net5.0` now.

Android has the following fixes:

* https://github.com/xamarin/xamarin-android/pull/4663
* https://github.com/xamarin/xamarin-android/pull/4692

This enables several workarounds to be removed.

Also use the same .NET 5 build as `xamarin-android`:

https://github.com/xamarin/xamarin-android/blob/cde7b79dce48d9f3fdfc396641a01fb27d165042/build-tools/automation/azure-pipelines.yaml#L53

I updated the `README.md` and our Azure DevOps build pipeline.