### PR TITLE
[android] update Xamarin.AndroidX.VectorDrawable

### DIFF
--- a/Directory.Android.targets
+++ b/Directory.Android.targets
@@ -1,8 +1,0 @@
-<Project>
-
-  <PropertyGroup>
-    <!-- Workaround to skip a .NET 4.5 MSBuild task: https://github.com/xamarin/AndroidSupportComponents/blob/68d28bc676673ec45f7f5ea2462c10bed87e2a2a/source/buildtasks/support-vector-drawable/Support-Vector-Drawable-BuildTasks.csproj#L10 -->
-    <VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
-  </PropertyGroup>
-
-</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,3 @@
 <Project>
-  <Import Condition="$(RuntimeIdentifier.StartsWith('android'))" Project="Directory.Android.targets" />
   <Import Condition="$(RuntimeIdentifier.StartsWith('ios'))"     Project="Directory.iOS.targets" />
 </Project>

--- a/HelloForms.Android/HelloForms.Android.csproj
+++ b/HelloForms.Android/HelloForms.Android.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
+    <!-- Needed until the dependencies are updated for Xamarin.Forms -->
+    <PackageReference Include="Xamarin.AndroidX.VectorDrawable" Version="1.1.0.1" />
     <ProjectReference Include="..\HelloForms\HelloForms.csproj" />
     <!--
       add few more packages to bring missing dependencies while linking

--- a/README.md
+++ b/README.md
@@ -77,19 +77,6 @@ package listing the same assembly in both:
 For now we added workarounds in `xamarin-android`, see
 [xamarin-android#4663](https://github.com/xamarin/xamarin-android/pull/4663).
 
-### AndroidX MSBuild tasks
-
-We need to port some MSBuild tasks to `netstandard2.0` such as:
-[Support-Vector-Drawable-BuildTasks.csproj#L10][1].
-
-We set `$(VectorDrawableCheckBuildToolsVersionTaskBeforeTargets)` to
-an empty string in `Directory.Build.targets` for now.
-
-[1]: https://github.com/xamarin/AndroidSupportComponents/blob/68d28bc676673ec45f7f5ea2462c10bed87e2a2a/source/buildtasks/support-vector-drawable/Support-Vector-Drawable-BuildTasks.csproj#L10
-
-Eventually, we can use a newer version of Xamarin.AndroidX.VectorDrawable
-with [AndroidX#103](https://github.com/xamarin/AndroidX/pull/103).
-
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/103

We removed the .NET framework 4.5 MSBuild task from VectorDrawable.

The Android projects in this repo no longer need any temporary workarounds.