### PR TITLE
[ci] Update primary and PR triggers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,10 @@
 # https://aka.ms/yaml
 
 trigger:
-- master
+- main
+
+pr:
+- main
 
 variables:
   DotNetVersion: 5.0.100-preview.7.20307.3


### PR DESCRIPTION
The default branch has been updated to `main`, and the pipeline build
triggers should be updated to reflect that change.