### PR TITLE
Bump to .NET 5.0.100-rc.1.20365.11

### DIFF
--- a/HelloForms.Android/HelloForms.Android.csproj
+++ b/HelloForms.Android/HelloForms.Android.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
+    <PackageReference Include="Xamarin.Forms" Version="4.7.0.1142" />
     <!-- Needed until the dependencies are updated for Xamarin.Forms -->
     <PackageReference Include="Xamarin.AndroidX.VectorDrawable" Version="1.1.0.1" />
     <ProjectReference Include="..\HelloForms\HelloForms.csproj" />

--- a/HelloForms.iOS/HelloForms.iOS.csproj
+++ b/HelloForms.iOS/HelloForms.iOS.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" GeneratePathProperty="true" />
+    <PackageReference Include="Xamarin.Forms" Version="4.7.0.1142" GeneratePathProperty="true" />
     <ProjectReference Include="..\HelloForms\HelloForms.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/HelloForms/HelloForms.csproj
+++ b/HelloForms/HelloForms.csproj
@@ -4,6 +4,6 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
+    <PackageReference Include="Xamarin.Forms" Version="4.7.0.1142" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pr:
 - main
 
 variables:
-  DotNetVersion: 5.0.100-preview.7.20307.3
+  DotNetVersion: 5.0.100-rc.1.20365.11
 
 jobs:
 - job: windows


### PR DESCRIPTION
When I originally tested this, I was getting a crash in Xamarin.Forms
on startup:

    FATAL EXCEPTION: main
    Process: com.microsoft.net5.helloforms, PID: 12221
    android.runtime.JavaProxyThrowable: System.TypeInitializationException: The type initializer for 'AndroidPlatformServices' threw an exception.
        ---> System.NotImplementedException: The method or operation is not implemented.
        at Internal.Cryptography.HashProviderDispenser.NotImplementedHashProvider.get_HashSizeInBytes()
        at System.Security.Cryptography.IncrementalHash..ctor(HashAlgorithmName name, HashProvider hash)
        at System.Security.Cryptography.IncrementalHash.CreateHash(HashAlgorithmName hashAlgorithm)
        at System.Security.Cryptography.MD5CryptoServiceProvider..ctor()
        at Xamarin.Forms.Forms.AndroidPlatformServices..cctor()
        --- End of inner exception stack trace ---
        at Xamarin.Forms.Forms.SetupInit(Context activity, Assembly resourceAssembly, Nullable`1 maybeOptions)
        at Xamarin.Forms.Forms.Init(Context activity, Bundle bundle)
        at HelloForms.Droid.MainActivity.OnCreate(Bundle savedInstanceState)
        at Android.App.Activity.n_OnCreate_Landroid_os_Bundle_(IntPtr jnienv, IntPtr native__this, IntPtr native_savedInstanceState)
        at crc6450e568c951913723.MainActivity.n_onCreate(Native Method)
        at crc6450e568c951913723.MainActivity.onCreate(MainActivity.java:37)
        at android.app.Activity.performCreate(Activity.java:7136)
        at android.app.Activity.performCreate(Activity.java:7127)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1271)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2893)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3048)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:78)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1808)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)

MD5 was removed in Xamarin.Forms 4.7.x, so this will probably be the
minimum working version for .NET 6.