### PR TITLE
[android] use targetSdkVersion="30"

### DIFF
--- a/HelloAndroid/Properties/AndroidManifest.xml
+++ b/HelloAndroid/Properties/AndroidManifest.xml
@@ -3,7 +3,7 @@
           android:versionCode="1" 
           android:versionName="1.0" 
           package="com.microsoft.net5.helloandroid">
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
   <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true">
   </application>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/HelloForms.Android/Properties/AndroidManifest.xml
+++ b/HelloForms.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.microsoft.net5.helloforms">
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
     <application android:label="Hello Forms"></application>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Projects:
 
 Prerequisites:
 
-* You will need the Android SDK installed as well as `Android SDK Platform 29`. Simplest way to get this is to install the current Xamarin workload and go to `Tools > Android > Android SDK Manager` from within Visual Studio.
+* You will need the Android SDK installed as well as `Android SDK Platform 30`. Simplest way to get this is to install the current Xamarin workload and go to `Tools > Android > Android SDK Manager` from within Visual Studio.
 
 For example, to build the Android project:
 


### PR DESCRIPTION
These projects currently hit the warning:

    warning XA1006: The TargetFrameworkVersion (Android API level 30) is higher than the targetSdkVersion (29). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.

We need to target API 30 instead.