### PR TITLE
Add net6 package feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet5" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="xamarin-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
   </packageSources>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="dotnet5" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="xamarin-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
   </packageSources>
   <config>


### PR DESCRIPTION
Without the feed it's not possible to build the `main` branch.


```sh
/Users/bruno/git/net6-samples/HelloForms.Droid/HelloForms.Droid.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Runtime.android-x86 with version (= 6.0.0-alpha.1.20453.28) [/Users/bruno/git/net6-samples/net6-samples.sln]
/Users/bruno/git/net6-samples/HelloForms.Droid/HelloForms.Droid.csproj : error NU1102:   - Found 436 version(s) in dotnet5 [ Nearest version: 6.0.0-alpha.1.20420.3 ] [/Users/bruno/git/net6-samples/net6-samples.sln]
/Users/bruno/git/net6-samples/HelloForms.Droid/HelloForms.Droid.csproj : error NU1102:   - Found 5 version(s) in nuget.org [ Nearest version: 5.0.0-preview.8.20407.11 ] [/Users/bruno/git/net6-samples/net6-samples.sln]
/Users/bruno/git/net6-samples/HelloForms.Droid/HelloForms.Droid.csproj : error NU1102:   - Found 0 version(s) in xamarin-impl [/Users/bruno/git/net6-samples/net6-samples.sln]

```