### PR TITLE
[android] use TargetFramework=net5.0-android and other cleanup

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,22 @@
 <Project>
   <Import Condition="$(RuntimeIdentifier.StartsWith('ios'))"     Project="Directory.iOS.targets" />
+
+  <PropertyGroup>
+    <_DotNetPackageVersion>5.0.0-rc.1.20451.14</_DotNetPackageVersion>
+  </PropertyGroup>
+  <!--
+    The linker resolves some assembly references too eagerly, and
+    fails when it can't find them, so work around this by referencing
+    the missing assemblies.
+    See: https://github.com/mono/linker/issues/1139
+  -->
+  <ItemGroup Condition=" '@(PackageReference->WithMetadataValue('Identity', 'Xamarin.Forms')->Count())' != '0' ">
+    <PackageReference Include="System.CodeDom"                        Version="$(_DotNetPackageVersion)" />
+    <PackageReference Include="System.Diagnostics.EventLog"           Version="$(_DotNetPackageVersion)" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(_DotNetPackageVersion)" />
+    <PackageReference Include="System.IO.Ports"                       Version="$(_DotNetPackageVersion)" />
+    <PackageReference Include="System.Security.Permissions"           Version="$(_DotNetPackageVersion)" />
+    <PackageReference Include="System.Threading.AccessControl"        Version="$(_DotNetPackageVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/HelloAndroid/HelloAndroid.csproj
+++ b/HelloAndroid/HelloAndroid.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.Android.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <RuntimeIdentifier>android.21-x86</RuntimeIdentifier>
+    <TargetFramework>net5.0-android</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 </Project>

--- a/HelloAndroid/Resources/values/strings.xml
+++ b/HelloAndroid/Resources/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_name">Hello Android</string>
-    <string name="app_text">Hello, .NET 5!</string>
+    <string name="app_text">Hello, .NET 6!</string>
 </resources>

--- a/HelloForms.Droid/HelloForms.Droid.csproj
+++ b/HelloForms.Droid/HelloForms.Droid.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.Android.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <RuntimeIdentifier>android.21-x86</RuntimeIdentifier>
+    <TargetFramework>net5.0-android</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
@@ -9,16 +8,5 @@
     <!-- Needed until the dependencies are updated for Xamarin.Forms -->
     <PackageReference Include="Xamarin.AndroidX.VectorDrawable" Version="1.1.0.1" />
     <ProjectReference Include="..\HelloForms\HelloForms.csproj" />
-    <!--
-      add few more packages to bring missing dependencies while linking
-      it is probably same issue as here: https://github.com/mono/linker/issues/1139
-      these should not be needed once we have the AndroidX packages targetting net5
-    -->
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.3.20214.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.3.20214.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.3.20214.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.3.20214.6" />
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.3.20214.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.3.20214.6" />
   </ItemGroup>
 </Project>

--- a/HelloForms.iOS/HelloForms.iOS.csproj
+++ b/HelloForms.iOS/HelloForms.iOS.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
@@ -8,16 +8,4 @@
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" GeneratePathProperty="true" />
     <ProjectReference Include="..\HelloForms\HelloForms.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <!-- The linker resolves some assembly references too eagerly, and fails when it can't find them, so work around this by referencing the missing assemblies-->
-    <!-- ref: https://github.com/mono/linker/issues/1139 -->
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.2.20160.6" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.2.20160.6" />
-  </ItemGroup>
-
 </Project>

--- a/HelloForms/HelloForms.csproj
+++ b/HelloForms/HelloForms.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />

--- a/HelloiOS/HelloiOS.csproj
+++ b/HelloiOS/HelloiOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -20,14 +20,9 @@ For example, to build the Android project:
 
     dotnet build HelloAndroid/HelloAndroid.csproj
 
-You can launch the Android project to an attached emulator via:
+You can launch the Android project to an attached emulator or device via:
 
     dotnet build HelloAndroid/HelloAndroid.csproj -t:Run
-
-To deploy and run on a device, you can either modify `$(RuntimeIdentifier)` in
-the `.csproj` or run:
-
-    dotnet build HelloAndroid/HelloAndroid.csproj -t:Run -r android.21-arm64
 
 ## iOS
 
@@ -49,7 +44,7 @@ To launch the iOS project on a simulator:
 
 Currently...
 
-* There is not a way to setup a binding project, neither for Xamarin.Android nor Xamarin.iOS.
+* There is not a way to setup a binding project for Xamarin.iOS.
 * `System.Console.WriteLine` does not work on Xamarin.Android. Use
   `Android.Util.Log.Debug` for now.
 * Building for device doesn't work for iOS.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,12 +7,12 @@ pr:
 - main
 
 variables:
-  DotNetVersion: 5.0.100-rc.1.20365.11
+  DotNetVersion: 5.0.100-rc.2.20459.1
 
 jobs:
 - job: windows
   pool:
-    name: Hosted Windows 2019 with VS2019
+    vmImage: windows-latest
   variables:
     LogDirectory: $(Build.ArtifactStagingDirectory)\logs
   steps:
@@ -49,7 +49,7 @@ jobs:
 
 - job: mac
   pool:
-    name: Hosted macOS
+    vmImage: macOS-latest
   variables:
     LogDirectory: $(Build.ArtifactStagingDirectory)/logs
   steps:
@@ -60,8 +60,7 @@ jobs:
       displayName: install .NET $(DotNetVersion)
 
     - bash: |
-        # Re-enable if Xcode 11.4.1 available or issue fixed: https://github.com/xamarin/xamarin-macios/issues/8325
-        # dotnet build net6-samples.sln -c Debug -bl:$(LogDirectory)/Debug.binlog &&
+        dotnet build net6-samples.sln -c Debug -bl:$(LogDirectory)/Debug.binlog &&
         dotnet build net6-samples.sln -c Release -bl:$(LogDirectory)/Release.binlog
       displayName: build samples
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,12 @@ jobs:
       displayName: install .NET $(DotNetVersion)
 
     - bash: |
+        set -x
+        mkdir -p ~/Library/Preferences/Xamarin
+        /usr/libexec/PlistBuddy -c "add :AppleSdkRoot string $(dirname $(dirname $(xcode-select -p)))" ~/Library/Preferences/Xamarin/Settings.plist
+      displayName: configure vsmac xcode
+
+    - bash: |
         dotnet build net6-samples.sln -c Debug -bl:$(LogDirectory)/Debug.binlog &&
         dotnet build net6-samples.sln -c Release -bl:$(LogDirectory)/Release.binlog
       displayName: build samples

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "msbuild-sdks": {
-            "Microsoft.iOS.Sdk": "13.5.100-ci.main.260",
-            "Microsoft.Android.Sdk": "11.0.100-ci.master.11"
+            "Microsoft.iOS.Sdk": "13.6.100-ci.main.379",
+            "Microsoft.Android.Sdk": "11.0.100-ci.master.127"
     }
 }


### PR DESCRIPTION
* Bump to .NET 5.0.100-rc.2.20459.1
* Bump to Microsoft.Android.Sdk 11.0.100-ci.master.127
* Consolidate `@(PackageReference)` needed for Xamarin.Forms projects
  in `Directory.Build.targets`.
* No need to declare `$(RuntimeIdentifier)` in Android projects. Use
  the defaults for these samples.
* `Hello, .NET 6!`
* `ProduceReferenceAssembly=true` is default in .NET 5+, not needed in
  `HelloForms.csproj`.
* Update `README.md` for Android specifics.