### PR TITLE
Bump to .NET 5.0.100-rc.2.20480.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,20 @@
 
 _This is an *early* preview of Xamarin in .NET 6 **not for production use**. Expect breaking changes as Xamarin is still in development for .NET 6._
 
-First install the [latest master build of .NET 6][0].
+This repo requires a specific build of .NET 5 rc 2:
+
+* https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.100-rc.2.20480.7/dotnet-sdk-5.0.100-rc.2.20480.7-win-x64.exe
+* https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.100-rc.2.20480.7/dotnet-sdk-5.0.100-rc.2.20480.7-osx-x64.pkg
+
+_NOTE: newer builds *may* work, but your mileage may vary. You can find the full list of builds at the [dotnet/installer][dotnet/installer] repo._
 
 Projects:
 
 * HelloAndroid - a native Xamarin.Android application
 * HelloiOS - a native Xamarin.iOS application
 * HelloForms, HelloForms.iOS, HelloForms.Droid - a cross-platform Xamarin.Forms application
+
+[dotnet/installer]: https://github.com/dotnet/installer#installers-and-binaries
 
 ## Android
 
@@ -37,8 +44,6 @@ To build the iOS project:
 To launch the iOS project on a simulator:
 
     dotnet build HelloiOS/HelloiOS.csproj -t:Run
-
-[0]: https://github.com/dotnet/installer#installers-and-binaries
 
 ## Known Issues
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,7 @@ jobs:
     vmImage: macOS-latest
   variables:
     - group: xamops-azdev-secrets
+    - group: Xamarin-Secrets
     - name: LogDirectory
       value: $(Build.ArtifactStagingDirectory)/logs
   steps:
@@ -65,7 +66,7 @@ jobs:
     - task: provisionator@2
       displayName: install Xcode
       inputs:
-        github_token: $(github-pat)
+        github_token: $(github--pat--vs-mobiletools-engineering-service2)
         provisioning_script: $(System.DefaultWorkingDirectory)/scripts/provision.csx
         provisioning_extra_args: '-v -v -v -v'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pr:
 - main
 
 variables:
-  DotNetVersion: 5.0.100-rc.2.20459.1
+  DotNetVersion: 5.0.100-rc.2.20480.7
 
 jobs:
 - job: windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,7 @@ jobs:
   pool:
     vmImage: macOS-latest
   variables:
+    - group: xamops-azdev-secrets
     - group: Xamarin-Secrets
     - name: LogDirectory
       value: $(Build.ArtifactStagingDirectory)/logs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,6 @@ jobs:
   pool:
     vmImage: macOS-latest
   variables:
-    - group: xamops-azdev-secrets
     - group: Xamarin-Secrets
     - name: LogDirectory
       value: $(Build.ArtifactStagingDirectory)/logs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,7 @@ jobs:
       condition: always()
 
 - job: mac
+  timeoutInMinutes: 120
   pool:
     vmImage: macOS-latest
   variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,13 +51,22 @@ jobs:
   pool:
     vmImage: macOS-latest
   variables:
-    LogDirectory: $(Build.ArtifactStagingDirectory)/logs
+    - group: xamops-azdev-secrets
+    - name: LogDirectory
+      value: $(Build.ArtifactStagingDirectory)/logs
   steps:
     - bash: >
         curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh &&
         sh dotnet-install.sh --version $(DotNetVersion) --install-dir ~/.dotnet/ --verbose &&
         dotnet --list-sdks
       displayName: install .NET $(DotNetVersion)
+
+    - task: provisionator@2
+      displayName: install Xcode
+      inputs:
+        github_token: $(github-pat)
+        provisioning_script: $(System.DefaultWorkingDirectory)/scripts/provision.csx
+        provisioning_extra_args: '-v -v -v -v'
 
     - bash: |
         set -x

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "msbuild-sdks": {
-            "Microsoft.iOS.Sdk": "13.6.100-ci.main.379",
-            "Microsoft.Android.Sdk": "11.0.100-ci.master.127"
+            "Microsoft.iOS.Sdk": "14.0.100-ci.main.559",
+            "Microsoft.Android.Sdk": "11.0.100-ci.master.169"
     }
 }

--- a/scripts/provision.csx
+++ b/scripts/provision.csx
@@ -1,0 +1,1 @@
+XcodeStable ().XcodeSelect ();


### PR DESCRIPTION
Context: https://github.com/xamarin/net6-samples/issues/35#issuecomment-704495534
Context: https://github.com/dotnet/sdk/commit/37d5ade0f863258a78313b8421eae0eb02d25c69

To account for the rename of `@(SdkSupportedTargetPlatform)` to
`@(SdkSupportedTargetPlatformVersion)`, we need to:

* Use .NET 5.0.100-rc.2.20480.7
* Use Microsoft.Android.Sdk 11.0.100-ci.master.169
* Use Microsoft.iOS.Sdk 14.0.100-ci.main.559