### PR TITLE
Bump to Microsoft.NET.Workload.Android 11.0.100.209

### DIFF
--- a/HelloAndroid/HelloAndroid.csproj
+++ b/HelloAndroid/HelloAndroid.csproj
@@ -2,7 +2,5 @@
   <PropertyGroup>
     <TargetFramework>net5.0-android</TargetFramework>
     <OutputType>Exe</OutputType>
-    <!-- TODO: disable Fast Deployment temporarily -->
-    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
 </Project>

--- a/HelloForms/Directory.Build.props
+++ b/HelloForms/Directory.Build.props
@@ -12,8 +12,6 @@
     <AndroidManifest>$(AndroidProjectFolder)AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>$(AndroidProjectFolder)Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>$(AndroidProjectFolder)Assets</MonoAndroidAssetsPrefix>
-    <!-- TODO: disable Fast Deployment temporarily -->
-    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <!-- iOS -->
     <iOSProjectFolder>iOS\</iOSProjectFolder>
     <IPhoneResourcePrefix>$(iOSProjectFolder)Resources</IPhoneResourcePrefix>

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This repo requires a specific build of .NET 5 rtm:
 You will also need to install builds of the iOS and Android workloads:
 
 Android:
-* Windows: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4181754/master/519ca83979916cfb1424ea4406639fd665fc1af7/Microsoft.NET.Workload.Android.11.0.100.208.msi
-* macOS: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4181754/master/519ca83979916cfb1424ea4406639fd665fc1af7/Microsoft.NET.Workload.Android-11.0.100-ci.master.208.pkg
+* Windows: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4183754/master/57c5a5fde5efd23f5958cfd8119b7f9c31d9e39d/Microsoft.NET.Workload.Android.11.0.100.209.msi
+* macOS: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4183754/master/57c5a5fde5efd23f5958cfd8119b7f9c31d9e39d/Microsoft.NET.Workload.Android-11.0.100-ci.master.209.pkg
 
 iOS:
 * Windows: Coming Soon

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,8 @@ pr:
 variables:
   DotNetVersion: 5.0.100-rtm.20509.5
   DotNet.Cli.Telemetry.OptOut: true
-  Android.Msi: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4181754/master/519ca83979916cfb1424ea4406639fd665fc1af7/Microsoft.NET.Workload.Android.11.0.100.208.msi
-  Android.Pkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4181754/master/519ca83979916cfb1424ea4406639fd665fc1af7/Microsoft.NET.Workload.Android-11.0.100-ci.master.208.pkg
+  Android.Msi: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4183754/master/57c5a5fde5efd23f5958cfd8119b7f9c31d9e39d/Microsoft.NET.Workload.Android.11.0.100.209.msi
+  Android.Pkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4183754/master/57c5a5fde5efd23f5958cfd8119b7f9c31d9e39d/Microsoft.NET.Workload.Android-11.0.100-ci.master.209.pkg
   iOS.Pkg: https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/923aef0838a64d7c2886716806c669d107fa399b/467/package/Microsoft.iOS.Bundle.14.1.100-ci.main.27.pkg
 
 jobs:


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5236

Fixes problem with Fast Deployment on Android caused by incorrect
paths in `@(ResolvedFilesToPublish)` from the dotnet/sdk.

Hoping it might help the random iOS failure, too? We saw things in the
build log such as:

    asset directory did not exist: /Users/runner/work/1/s/HelloAndroid/obj/Debug/net5.0-android/assets/ (TaskId:253)
    Executing link --manifest /Users/runner/work/1/s/HelloAndroid/obj/Debug/net5.0-android/android/manifest/AndroidManifest.xml [...]
    ILLINK : error MT2301: The linker step 'Setup' failed during processing. [/Users/runner/work/1/s/HelloiOS/HelloiOS.csproj]

`net6-samples.sln` will build projects in parallel, so we're not sure
if the Android log message is affecting the iOS build or not.