### PR TITLE
Pin to .NET 5.0.100-rtm.20509.5

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
     "sdk": {
         "version": "5.0.100-rtm.20509.5",
-        "rollForward": "major",
+        "rollForward": "disable",
         "allowPrerelease": true
     }
 }


### PR DESCRIPTION
Since .NET 5.0 GA came out yesterday, the GA version is preferred over
the rtm build currently specified in `global.json`.

Set `"rollForward": "disable"`, so the right version is used by
default.