### PR TITLE
[HelloForms] fix *.cs wildcards

### DIFF
--- a/HelloForms/Directory.Build.props
+++ b/HelloForms/Directory.Build.props
@@ -19,13 +19,13 @@
 
   <!-- Shared -->
   <ItemGroup>
-    <Compile Include="Shared\**$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <Compile Include="Shared\**\*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <EmbeddedResource Include="Shared\**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
 
   <!-- Android -->
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
-    <Compile Include="$(AndroidProjectFolder)**$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <Compile Include="$(AndroidProjectFolder)**\*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.xml" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.axml" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.png" />
@@ -40,7 +40,7 @@
 
   <!-- iOS -->
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'ios' ">
-    <Compile Include="$(iOSProjectFolder)**$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <Compile Include="$(iOSProjectFolder)**\*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" />
     <SceneKitAsset Include="$(iOSProjectFolder)**\*.scnassets\*">
       <IsDefaultItem>true</IsDefaultItem>


### PR DESCRIPTION
Testing the HelloForms app I noticed `CoreCompile` always runs:

    Building target "CoreCompile" completely.
    Input file "Shared/**.cs" does not exist.

We actually need to be using `Shared\**\*.cs` as the wildcard. I needed
to fix the Android and iOS directories as well.