### PR TITLE
Bump to .NET 6.0.100-alpha.1.20562.2

### DIFF
--- a/HelloAndroid/HelloAndroid.csproj
+++ b/HelloAndroid/HelloAndroid.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-android</TargetFramework>
+    <TargetFramework>net6.0-android</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 </Project>

--- a/HelloAndroid/Properties/AndroidManifest.xml
+++ b/HelloAndroid/Properties/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" 
           android:versionCode="1" 
           android:versionName="1.0" 
-          package="com.microsoft.net5.helloandroid">
+          package="com.microsoft.net6.helloandroid">
   <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
   <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true">
   </application>

--- a/HelloForms/Android/AndroidManifest.xml
+++ b/HelloForms/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.microsoft.net5.helloforms">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.microsoft.net6.helloforms">
     <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
     <application android:label="Hello Forms"></application>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/HelloForms/Directory.Build.props
+++ b/HelloForms/Directory.Build.props
@@ -74,7 +74,7 @@
     See: https://github.com/mono/linker/issues/1139
   -->
   <PropertyGroup>
-    <_DotNetPackageVersion>5.0.0-rc.2.20475.5</_DotNetPackageVersion>
+    <_DotNetPackageVersion>5.0.0</_DotNetPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.CodeDom"                        Version="$(_DotNetPackageVersion)" />

--- a/HelloForms/HelloForms.csproj
+++ b/HelloForms/HelloForms.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0-android;net5.0-ios</TargetFrameworks>
-    <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net5.0-ios' ">ios-x64</RuntimeIdentifier>
+    <TargetFrameworks>net6.0-android;net6.0-ios</TargetFrameworks>
+    <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net6.0-ios' ">ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/HelloForms/iOS/Info.plist
+++ b/HelloForms/iOS/Info.plist
@@ -25,7 +25,7 @@
     <key>CFBundleDisplayName</key>
     <string>HelloForms</string>
     <key>CFBundleIdentifier</key>
-    <string>com.microsoft.net5.helloforms</string>
+    <string>com.microsoft.net6.helloforms</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
     <key>UILaunchStoryboardName</key>

--- a/HelloiOS/HelloiOS.csproj
+++ b/HelloiOS/HelloiOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-ios</TargetFramework>
+    <TargetFramework>net6.0-ios</TargetFramework>
     <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/HelloiOS/Info.plist
+++ b/HelloiOS/Info.plist
@@ -5,7 +5,7 @@
     <key>CFBundleDisplayName</key>
     <string>Hello iOS</string>
     <key>CFBundleIdentifier</key>
-    <string>com.microsoft.net5.helloios</string>
+    <string>com.microsoft.net6.helloios</string>
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -2,25 +2,25 @@
 
 _This is an *early* preview of Xamarin in .NET 6 **not for production use**. Expect breaking changes as Xamarin is still in development for .NET 6._
 
-This repo requires a specific build of .NET 5 rtm:
+This repo requires a specific build of .NET 6:
 
-* Windows: [dotnet-sdk-5.0.100-rtm.20509.5-win-x64.exe](https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.100-rtm.20509.5/dotnet-sdk-5.0.100-rtm.20509.5-win-x64.exe)
-* macOS: [dotnet-sdk-5.0.100-rtm.20509.5-osx-x64.pkg](https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.100-rtm.20509.5/dotnet-sdk-5.0.100-rtm.20509.5-osx-x64.pkg)
+* Windows: [dotnet-sdk-6.0.100-alpha.1.20562.2-win-x64.exe](https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100-alpha.1.20562.2/dotnet-sdk-6.0.100-alpha.1.20562.2-win-x64.exe)
+* macOS: [dotnet-sdk-6.0.100-alpha.1.20562.2-osx-x64.pkg](https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100-alpha.1.20562.2/dotnet-sdk-6.0.100-alpha.1.20562.2-osx-x64.pkg)
 
 You will also need to install builds of the iOS and Android workloads:
 
 Android:
-* Windows: [Microsoft.NET.Workload.Android.11.0.100.209.msi](https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4183754/master/57c5a5fde5efd23f5958cfd8119b7f9c31d9e39d/Microsoft.NET.Workload.Android.11.0.100.209.msi)
-* macOS: [Microsoft.NET.Workload.Android-11.0.100-ci.master.209.pkg](https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4183754/master/57c5a5fde5efd23f5958cfd8119b7f9c31d9e39d/Microsoft.NET.Workload.Android-11.0.100-ci.master.209.pkg)
+* Windows: [Microsoft.NET.Workload.Android.11.0.100.245.msi](https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4241621/master/6e3e3831afa958ab8126e268f7a128321f75dbd6/Microsoft.NET.Workload.Android.11.0.100.245.msi)
+* macOS: [Microsoft.NET.Workload.Android-11.0.100-ci.master.245.pkg](https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4241621/master/6e3e3831afa958ab8126e268f7a128321f75dbd6/Microsoft.NET.Workload.Android-11.0.100-ci.master.245.pkg)
 
 iOS:
 
-* Windows: [Microsoft.NET.Workload.iOS.14.1.100-ci.main.52.msi](https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/90bfb623ed14defe2475b5dd9040492c3f7048c9/492/package/Microsoft.NET.Workload.iOS.14.1.100-ci.main.52.msi)
-* macOS: [Microsoft.iOS.Bundle.14.1.100-ci.main.52.pkg](https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/90bfb623ed14defe2475b5dd9040492c3f7048c9/492/package/Microsoft.iOS.Bundle.14.1.100-ci.main.52.pkg)
+* Windows: [Microsoft.NET.Workload.iOS.14.2.100-ci.main.30.msi](https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/3174e94a178c41cae0a51fa296e52f711957c14a/543/package/Microsoft.NET.Workload.iOS.14.2.100-ci.main.30.msi)
+* macOS: [Microsoft.iOS.Bundle.14.2.100-ci.main.30.pkg](https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/3174e94a178c41cae0a51fa296e52f711957c14a/543/package/Microsoft.iOS.Bundle.14.2.100-ci.main.30.pkg)
 
-_NOTE: newer builds of .NET 5 *may* work, but your mileage may vary.
+_NOTE: newer builds of .NET *may* work, but your mileage may vary.
 The workload installers enable a feature flag file via
-`sdk/5.0.100-rtm.20509.5/EnableWorkloadResolver.sentinel`, which would
+`sdk/6.0.100-alpha.1.20562.2/EnableWorkloadResolver.sentinel`, which would
 need to be created manually for other .NET 5 versions. You can find
 the full list of builds at the [dotnet/installer][dotnet/installer]
 repo._
@@ -51,7 +51,7 @@ You can launch the Android project to an attached emulator or device via:
 
 Prerequisites:
 
-* Xcode 12.1. Earlier versions won't work.
+* Xcode 12.2. Earlier versions won't work.
 
 To build the iOS project:
 
@@ -65,8 +65,8 @@ To launch the iOS project on a simulator:
 
 To launch the Forms project, you will need to specify a `$(TargetFramework)`:
 
-    dotnet build HelloForms/HelloForms.csproj -t:Run -p:TargetFramework=net5.0-android
-    dotnet build HelloForms/HelloForms.csproj -t:Run -p:TargetFramework=net5.0-ios
+    dotnet build HelloForms/HelloForms.csproj -t:Run -p:TargetFramework=net6.0-android
+    dotnet build HelloForms/HelloForms.csproj -t:Run -p:TargetFramework=net6.0-ios
 
 ## Known Issues
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,12 +7,12 @@ pr:
 - main
 
 variables:
-  DotNetVersion: 5.0.100-rtm.20509.5
+  DotNetVersion: 6.0.100-alpha.1.20562.2
   DotNet.Cli.Telemetry.OptOut: true
-  Android.Msi: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4183754/master/57c5a5fde5efd23f5958cfd8119b7f9c31d9e39d/Microsoft.NET.Workload.Android.11.0.100.209.msi
-  Android.Pkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4183754/master/57c5a5fde5efd23f5958cfd8119b7f9c31d9e39d/Microsoft.NET.Workload.Android-11.0.100-ci.master.209.pkg
-  iOS.Msi: https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/90bfb623ed14defe2475b5dd9040492c3f7048c9/492/package/Microsoft.NET.Workload.iOS.14.1.100-ci.main.52.msi
-  iOS.Pkg: https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/90bfb623ed14defe2475b5dd9040492c3f7048c9/492/package/Microsoft.iOS.Bundle.14.1.100-ci.main.52.pkg
+  Android.Msi: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4241621/master/6e3e3831afa958ab8126e268f7a128321f75dbd6/Microsoft.NET.Workload.Android.11.0.100.245.msi
+  Android.Pkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4241621/master/6e3e3831afa958ab8126e268f7a128321f75dbd6/Microsoft.NET.Workload.Android-11.0.100-ci.master.245.pkg
+  iOS.Msi: https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/3174e94a178c41cae0a51fa296e52f711957c14a/543/package/Microsoft.NET.Workload.iOS.14.2.100-ci.main.30.msi
+  iOS.Pkg: https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/3174e94a178c41cae0a51fa296e52f711957c14a/543/package/Microsoft.iOS.Bundle.14.2.100-ci.main.30.pkg
 
 jobs:
 - job: windows

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.100-rtm.20509.5",
+        "version": "6.0.100-alpha.1.20562.2",
         "rollForward": "disable",
         "allowPrerelease": true
     }

--- a/scripts/provision.csx
+++ b/scripts/provision.csx
@@ -1,1 +1,1 @@
-Xcode ("12.1").XcodeSelect ();
+Xcode ("12.2").XcodeSelect ();


### PR DESCRIPTION
* Everything is `net6.0` now
* Android 11.0.100.239
* iOS 14.2.100.27
* `$(_DotNetPackageVersion)` can use 5.0.0 stable NuGet packages