### PR TITLE
Set LaunchMode.SingleTop for MainActivity on Android

### DIFF
--- a/9.0/Apps/BugSweeper/BugSweeper/Platforms/Android/MainActivity.cs
+++ b/9.0/Apps/BugSweeper/BugSweeper/Platforms/Android/MainActivity.cs
@@ -5,6 +5,7 @@ using Android.OS;
 namespace BugSweeper
 {
     [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }


### PR DESCRIPTION
Updated MainActivity to use "LaunchMode.SingleTop" to prevent multiple instances of the activity when the app is reopened from the launcher. The app’s behavior ensures that the activity stack remains clean.