### PR TITLE
Resolved the chart data label binding issues on release mode.

### DIFF
--- a/10.0/Apps/DeveloperBalance/Pages/Controls/CategoryChart.xaml
+++ b/10.0/Apps/DeveloperBalance/Pages/Controls/CategoryChart.xaml
@@ -2,17 +2,18 @@
 <Border xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
         xmlns:chart="clr-namespace:Syncfusion.Maui.Toolkit.Charts;assembly=Syncfusion.Maui.Toolkit"
-        xmlns:controls="clr-namespace:DeveloperBalance.Pages.Controls" 
+        xmlns:controls="clr-namespace:DeveloperBalance.Pages.Controls"
         xmlns:shimmer="clr-namespace:Syncfusion.Maui.Toolkit.Shimmer;assembly=Syncfusion.Maui.Toolkit"
         xmlns:pageModels="clr-namespace:DeveloperBalance.PageModels"
         x:Class="DeveloperBalance.Pages.Controls.CategoryChart"
         HeightRequest="{OnIdiom 300, Phone=200}"
+        x:DataType="pageModels:MainPageModel"
         Style="{StaticResource CardStyle}">
     <shimmer:SfShimmer
         AutomationProperties.IsInAccessibleTree="False"
         BackgroundColor="Transparent"
         VerticalOptions="Fill"
-        IsActive ="{Binding IsBusy}">
+        IsActive="{Binding IsBusy}">
         <shimmer:SfShimmer.CustomView>
             <Grid>
                 <BoxView
@@ -22,8 +23,12 @@
             </Grid>
         </shimmer:SfShimmer.CustomView>
         <shimmer:SfShimmer.Content>
-            <chart:SfCircularChart x:Name="Chart" SemanticProperties.Description="Task Categories Chart">
-                <chart:DoughnutSeries
+            <chart:SfCircularChart x:Name="Chart"
+                    SemanticProperties.Description="Task Categories Chart">
+                <chart:SfCircularChart.Resources>
+                    <controls:ChartDataLabelConverter x:Key="ChartDataLabelConverter"/>
+                </chart:SfCircularChart.Resources>
+                <chart:DoughnutSeries 
                     ItemsSource="{Binding TodoCategoryData}"
                     PaletteBrushes="{Binding TodoCategoryColors}"
                     XBindingPath="Title"
@@ -32,27 +37,35 @@
                     EnableTooltip="False"
                     x:Name="doughnutSeries"
                     Radius="{OnIdiom 0.6, Phone=0.5}"
-                    InnerRadius="0.7" >
+                    InnerRadius="0.7">
                     <chart:DoughnutSeries.LabelTemplate>
-                        <DataTemplate >
-                            <HorizontalStackLayout>
-                                <Label Text="{Binding Item.Title}" TextColor="{AppThemeBinding
+                        <DataTemplate>
+                            <HorizontalStackLayout x:DataType="chart:ChartDataLabel">
+                                <Label Text="{Binding Item, Converter={StaticResource ChartDataLabelConverter}, ConverterParameter='title'}"
+                                        TextColor="{AppThemeBinding 
                                     Light={StaticResource DarkOnLightBackground},
-                                    Dark={StaticResource LightOnDarkBackground}}" FontSize="{OnIdiom 18, Phone=14}"/>
-                                <Label Text=": " TextColor="{AppThemeBinding
+                                    Dark={StaticResource LightOnDarkBackground}}"
+                                        FontSize="{OnIdiom 18, Phone=14}"/>
+                                <Label Text=": "
+                                        TextColor="{AppThemeBinding
                                     Light={StaticResource DarkOnLightBackground},
-                                    Dark={StaticResource LightOnDarkBackground}}" FontSize="{OnIdiom 18, Phone=14}"/>
-                                <Label Text="{Binding Item.Count}" TextColor="{AppThemeBinding
+                                    Dark={StaticResource LightOnDarkBackground}}"
+                                        FontSize="{OnIdiom 18, Phone=14}"/>
+                                <Label Text="{Binding Item, Converter={StaticResource ChartDataLabelConverter}, ConverterParameter='count'}"
+                                        TextColor="{AppThemeBinding
                                     Light={StaticResource DarkOnLightBackground},
-                                    Dark={StaticResource LightOnDarkBackground}}" FontSize="{OnIdiom 18, Phone=14}"/>
+                                    Dark={StaticResource LightOnDarkBackground}}"
+                                        FontSize="{OnIdiom 18, Phone=14}"/>
                             </HorizontalStackLayout>
                         </DataTemplate>
                     </chart:DoughnutSeries.LabelTemplate>
 
                     <chart:DoughnutSeries.DataLabelSettings>
-                        <chart:CircularDataLabelSettings LabelPosition="Outside" SmartLabelAlignment="Shift">
+                        <chart:CircularDataLabelSettings LabelPosition="Outside"
+                                SmartLabelAlignment="Shift">
                             <chart:CircularDataLabelSettings.ConnectorLineSettings>
-                                <chart:ConnectorLineStyle ConnectorType="Line" StrokeWidth="3" ></chart:ConnectorLineStyle>
+                                <chart:ConnectorLineStyle ConnectorType="Line"
+                                        StrokeWidth="3"></chart:ConnectorLineStyle>
                             </chart:CircularDataLabelSettings.ConnectorLineSettings>
                         </chart:CircularDataLabelSettings>
                     </chart:DoughnutSeries.DataLabelSettings>

--- a/10.0/Apps/DeveloperBalance/Pages/Controls/ChartDataLabelConverter.cs
+++ b/10.0/Apps/DeveloperBalance/Pages/Controls/ChartDataLabelConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Globalization;
+using DeveloperBalance.Models;
+
+namespace DeveloperBalance.Pages.Controls;
+
+public class ChartDataLabelConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is CategoryChartData categoryData && parameter is string parameterValue)
+        {
+            return parameterValue?.ToLower() switch
+            {
+                "title" => categoryData.Title,
+                "count" => categoryData.Count.ToString(),
+                _ => value?.ToString()
+            };
+        }
+        
+        return value?.ToString();
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION

This pull request resolves an issue where nested bindings of custom chart data label objects were not working properly in Release mode due to AOT compilation being enabled in the chart library.
To address this, a Converter class has been added to ensure the bindings work correctly in all build modes

**Chart Data Label Formatting Improvements:**

* Added the new `ChartDataLabelConverter` class to provide custom formatting for chart data labels, allowing the chart to display either the category title or count based on the converter parameter. (`10.0/Apps/DeveloperBalance/Pages/Controls/ChartDataLabelConverter.cs`)
* Registered the `ChartDataLabelConverter` as a resource in the `SfCircularChart` so it can be used in label templates. (`10.0/Apps/DeveloperBalance/Pages/Controls/CategoryChart.xaml`)
* Updated the chart label template to use the converter for both the title and count fields, replacing direct property bindings with converter-based bindings for improved flexibility and maintainability. (`10.0/Apps/DeveloperBalance/Pages/Controls/CategoryChart.xaml`)

**Type Safety and XAML Enhancements:**

* Added `x:DataType="pageModels:MainPageModel"` to the root element of `CategoryChart.xaml` to enable compile-time type checking and resolved the binding warnings. . (`10.0/Apps/DeveloperBalance/Pages/Controls/CategoryChart.xaml`)
* Specified `x:DataType="chart:ChartDataLabel"` in the `HorizontalStackLayout` within the label template for better type safety in the data template. (`10.0/Apps/DeveloperBalance/Pages/Controls/CategoryChart.xaml`)