### PR TITLE
Android: Set `LaunchMode.SingleTop` for `MainActivity`

### DIFF
--- a/10.0/Animations/Animations/Platforms/Android/MainActivity.cs
+++ b/10.0/Animations/Animations/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Animations;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Apps/BugSweeper/BugSweeper/Platforms/Android/MainActivity.cs
+++ b/10.0/Apps/BugSweeper/BugSweeper/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace BugSweeper
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/10.0/Apps/Calculator/src/Calculator/Platforms/Android/MainActivity.cs
+++ b/10.0/Apps/Calculator/src/Calculator/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Calculator;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Apps/GameOfLife/GameOfLife/Platforms/Android/MainActivity.cs
+++ b/10.0/Apps/GameOfLife/GameOfLife/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace GameOfLife;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Apps/PointOfSale/src/PointOfSale/Platforms/Android/MainActivity.cs
+++ b/10.0/Apps/PointOfSale/src/PointOfSale/Platforms/Android/MainActivity.cs
@@ -7,7 +7,7 @@ using PointOfSale.Data;
 
 namespace PointOfSale;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
 public class MainActivity : MauiAppCompatActivity
 {
     protected override void OnCreate(Bundle savedInstanceState)

--- a/10.0/Apps/WeatherTwentyOne/src/WeatherTwentyOne/Platforms/Android/MainActivity.cs
+++ b/10.0/Apps/WeatherTwentyOne/src/WeatherTwentyOne/Platforms/Android/MainActivity.cs
@@ -7,7 +7,7 @@ namespace WeatherTwentyOne;
 [IntentFilter(
     new[] { Platform.Intent.ActionAppAction },
 	Categories = new[] { Android.Content.Intent.CategoryDefault })]
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
 public class MainActivity : MauiAppCompatActivity
 {
     protected override void OnCreate(Bundle savedInstanceState)

--- a/10.0/Apps/WhatToEat/src/WhatToEat/Platforms/Android/MainActivity.cs
+++ b/10.0/Apps/WhatToEat/src/WhatToEat/Platforms/Android/MainActivity.cs
@@ -5,7 +5,7 @@ using Microsoft.Maui.ApplicationModel;
 
 namespace Recipes
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/10.0/Apps/WordPuzzle/WordPuzzle/Platforms/Android/MainActivity.cs
+++ b/10.0/Apps/WordPuzzle/WordPuzzle/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace WordPuzzle
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/10.0/Beginners-Series/BeginnersTask/Platforms/Android/MainActivity.cs
+++ b/10.0/Beginners-Series/BeginnersTask/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace BeginnersTasks;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Data/TodoSQLite/TodoSQLite/Platforms/Android/MainActivity.cs
+++ b/10.0/Data/TodoSQLite/TodoSQLite/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TodoSQLite;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Fundamentals/BehaviorsDemos/BehaviorsDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/Fundamentals/BehaviorsDemos/BehaviorsDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace BehaviorsDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Fundamentals/ContextMenu/ContextMenuSample/Platforms/Android/MainActivity.cs
+++ b/10.0/Fundamentals/ContextMenu/ContextMenuSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ContextMenuSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Fundamentals/ControlTemplateDemos/ControlTemplateDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/Fundamentals/ControlTemplateDemos/ControlTemplateDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ControlTemplateDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Fundamentals/DataBindingDemos/DataBindingDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/Fundamentals/DataBindingDemos/DataBindingDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace DataBindingDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Fundamentals/DataTemplateDemos/DataTemplates/Platforms/Android/MainActivity.cs
+++ b/10.0/Fundamentals/DataTemplateDemos/DataTemplates/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace DataTemplates;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Fundamentals/Localization/LocalizationDemo/Platforms/Android/MainActivity.cs
+++ b/10.0/Fundamentals/Localization/LocalizationDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace LocalizationDemo
 {
-    [Activity(Label = "@string/app_name", Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Label = "@string/app_name", Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
         protected override void OnCreate(Bundle savedInstanceState)

--- a/10.0/Fundamentals/Shell/Xaminals/Platforms/Android/MainActivity.cs
+++ b/10.0/Fundamentals/Shell/Xaminals/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Xaminals;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Fundamentals/Tooltips/TooltipsSample/Platforms/Android/MainActivity.cs
+++ b/10.0/Fundamentals/Tooltips/TooltipsSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TooltipsSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Fundamentals/TriggersDemos/WorkingWithTriggers/Platforms/Android/MainActivity.cs
+++ b/10.0/Fundamentals/TriggersDemos/WorkingWithTriggers/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace WorkingWithTriggers;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Navigation/FlyoutPageSample/FlyoutPageSample/Platforms/Android/MainActivity.cs
+++ b/10.0/Navigation/FlyoutPageSample/FlyoutPageSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace FlyoutPageSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Navigation/ShellFlyoutSample/ShellFlyoutSample/Platforms/Android/MainActivity.cs
+++ b/10.0/Navigation/ShellFlyoutSample/ShellFlyoutSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ShellFlyoutSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Navigation/ShellMixedSample/ShellMixedSample/Platforms/Android/MainActivity.cs
+++ b/10.0/Navigation/ShellMixedSample/ShellMixedSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ShellMixedSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Navigation/ShellTabBarSample/ShellTabBarSample/Platforms/Android/MainActivity.cs
+++ b/10.0/Navigation/ShellTabBarSample/ShellTabBarSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ShellTabBarSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Navigation/TabbedPage/TabbedPage/Platforms/Android/MainActivity.cs
+++ b/10.0/Navigation/TabbedPage/TabbedPage/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TabbedPageSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/PlatformIntegration/InvokePlatformCodeDemos/InvokePlatformCodeDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/PlatformIntegration/InvokePlatformCodeDemos/InvokePlatformCodeDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace InvokePlatformCodeDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/PlatformIntegration/NativeEmbeddingDemo/NativeEmbeddingDemo.Droid/MainActivity.cs
+++ b/10.0/PlatformIntegration/NativeEmbeddingDemo/NativeEmbeddingDemo.Droid/MainActivity.cs
@@ -8,7 +8,7 @@ using Toolbar = AndroidX.AppCompat.Widget.Toolbar;
 
 namespace NativeEmbeddingDemo.Droid
 {
-    [Activity(Label = "@string/app_name", MainLauncher = true, Theme = "@style/Theme.MyApplication")]
+    [Activity(Label = "@string/app_name", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, Theme = "@style/Theme.MyApplication")]
     public class MainActivity : AppCompatActivity
     {
         AppBarConfiguration? appBarConfiguration;

--- a/10.0/PlatformIntegration/NativeEmbeddingDemo/TestHarnessApp/Platforms/Android/MainActivity.cs
+++ b/10.0/PlatformIntegration/NativeEmbeddingDemo/TestHarnessApp/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TestHarnessApp;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/PlatformIntegration/PlatformIntegrationDemos/PlatformIntegrationDemo/Platforms/Android/MainActivity.cs
+++ b/10.0/PlatformIntegration/PlatformIntegrationDemos/PlatformIntegrationDemo/Platforms/Android/MainActivity.cs
@@ -6,7 +6,7 @@ using Android.Widget;
 
 namespace PlatformIntegrationDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density, ScreenOrientation = ScreenOrientation.FullSensor)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density, ScreenOrientation = ScreenOrientation.FullSensor)]
 [IntentFilter(
         new[] { Microsoft.Maui.ApplicationModel.Platform.Intent.ActionAppAction },
         Categories = new[] { Intent.CategoryDefault })]

--- a/10.0/SkiaSharp/MandelbrotAnimation/MandelbrotAnimation/Platforms/Android/MainActivity.cs
+++ b/10.0/SkiaSharp/MandelbrotAnimation/MandelbrotAnimation/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MandelbrotAnimation;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/SkiaSharp/PhotoPuzzle/PhotoPuzzle/Platforms/Android/MainActivity.cs
+++ b/10.0/SkiaSharp/PhotoPuzzle/PhotoPuzzle/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace PhotoPuzzle;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/SkiaSharp/SkiaSharpDemos/SkiaSharpDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/SkiaSharp/SkiaSharpDemos/SkiaSharpDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace SkiaSharpDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/SkiaSharp/SpinPaint/SpinPaint/Platforms/Android/MainActivity.cs
+++ b/10.0/SkiaSharp/SpinPaint/SpinPaint/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace SpinPaint;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/Tutorials/ConvertToMvvm/code/Platforms/Android/MainActivity.cs
+++ b/10.0/Tutorials/ConvertToMvvm/code/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Notes
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/10.0/Tutorials/CreateNetMauiApp/code/Platforms/Android/MainActivity.cs
+++ b/10.0/Tutorials/CreateNetMauiApp/code/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Notes
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/10.0/UITesting/BasicAppiumNunitSample/MauiApp/Platforms/Android/MainActivity.cs
+++ b/10.0/UITesting/BasicAppiumNunitSample/MauiApp/Platforms/Android/MainActivity.cs
@@ -5,7 +5,7 @@ using Android.Runtime;
 
 namespace BasicAppiumSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 [Register("com.companyname.basicappiumsample.MainActivity")]
 public class MainActivity : MauiAppCompatActivity
 {

--- a/10.0/UITesting/BrowserStackAppiumMaui/BasicAppiumNunitSample/MauiApp/Platforms/Android/MainActivity.cs
+++ b/10.0/UITesting/BrowserStackAppiumMaui/BasicAppiumNunitSample/MauiApp/Platforms/Android/MainActivity.cs
@@ -5,7 +5,7 @@ using Android.Runtime;
 
 namespace BasicAppiumSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 [Register("com.companyname.basicappiumsample.MainActivity")]
 public class MainActivity : MauiAppCompatActivity
 {

--- a/10.0/UserInterface/Handlers/CreateHandlerDemo/VideoDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Handlers/CreateHandlerDemo/VideoDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace VideoDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Handlers/CustomizeHandlersDemo/CustomizeHandlersDemo/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Handlers/CustomizeHandlersDemo/CustomizeHandlersDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace CustomizeHandlersDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/HyperlinkDemo/HyperlinkDemo/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/HyperlinkDemo/HyperlinkDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace HyperlinkDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Layouts/AbsoluteLayoutDemos/AbsoluteLayoutDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Layouts/AbsoluteLayoutDemos/AbsoluteLayoutDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace AbsoluteLayoutDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Layouts/BindableLayoutDemos/BindableLayoutDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Layouts/BindableLayoutDemos/BindableLayoutDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace BindableLayoutDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Layouts/CustomLayoutDemos/CustomLayoutDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Layouts/CustomLayoutDemos/CustomLayoutDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace CustomLayoutDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Layouts/FlexLayoutDemos/FlexLayoutDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Layouts/FlexLayoutDemos/FlexLayoutDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace FlexLayoutDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Layouts/GridDemos/GridDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Layouts/GridDemos/GridDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace GridDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Layouts/StackLayoutDemos/StackLayoutDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Layouts/StackLayoutDemos/StackLayoutDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace StackLayoutDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/SystemThemesDemo/SystemThemesDemo/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/SystemThemesDemo/SystemThemesDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace SystemThemesDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/ThemingDemo/ThemingDemo/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/ThemingDemo/ThemingDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ThemingDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/CarouselViewDemos/CarouselViewDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/CarouselViewDemos/CarouselViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace CarouselViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/CheckBoxDemos/CheckBoxDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/CheckBoxDemos/CheckBoxDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace CheckBoxDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace CollectionViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/GraphicsViewDemos/GraphicsViewDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/GraphicsViewDemos/GraphicsViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace GraphicsViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/IndicatorViewDemos/IndicatorViewDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/IndicatorViewDemos/IndicatorViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace IndicatorViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/ListViewDemos/ListViewDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/ListViewDemos/ListViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ListViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/Map/MapDemo/WorkingWithMaps/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/Map/MapDemo/WorkingWithMaps/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace WorkingWithMaps;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/RadioButtonDemos/RadioButtonDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/RadioButtonDemos/RadioButtonDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace RadioButtonDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/RefreshViewDemo/RefreshViewDemo/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/RefreshViewDemo/RefreshViewDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace RefreshViewDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/ScrollViewDemos/ScrollViewDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/ScrollViewDemos/ScrollViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ScrollViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/ShapesDemos/ShapesDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/ShapesDemos/ShapesDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ShapesDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/SwipeViewDemos/SwipeViewDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/SwipeViewDemos/SwipeViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace SwipeViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/SwitchDemos/SwitchDemos/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/SwitchDemos/SwitchDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace SwitchDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/Views/TwoPaneView/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/Views/TwoPaneView/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MauiTwoPaneViewDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/WorkingWithColors/WorkingWithColors/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/WorkingWithColors/WorkingWithColors/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace WorkingWithColors;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/UserInterface/WorkingWithFiles/WorkingWithFiles/Platforms/Android/MainActivity.cs
+++ b/10.0/UserInterface/WorkingWithFiles/WorkingWithFiles/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace WorkingWithFiles;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/WebServices/TodoREST/TodoREST/Platforms/Android/MainActivity.cs
+++ b/10.0/WebServices/TodoREST/TodoREST/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TodoREST;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/XAML/Fundamentals/XamlSamples/Platforms/Android/MainActivity.cs
+++ b/10.0/XAML/Fundamentals/XamlSamples/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace XamlSamples;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/10.0/XAML/MarkupExtensions/MarkupExtensions/Platforms/Android/MainActivity.cs
+++ b/10.0/XAML/MarkupExtensions/MarkupExtensions/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MarkupExtensions;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Animations/Animations/Platforms/Android/MainActivity.cs
+++ b/9.0/Animations/Animations/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Animations;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Apps/BugSweeper/BugSweeper/Platforms/Android/MainActivity.cs
+++ b/9.0/Apps/BugSweeper/BugSweeper/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace BugSweeper
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/9.0/Apps/Calculator/src/Calculator/Platforms/Android/MainActivity.cs
+++ b/9.0/Apps/Calculator/src/Calculator/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Calculator;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Apps/GameOfLife/GameOfLife/Platforms/Android/MainActivity.cs
+++ b/9.0/Apps/GameOfLife/GameOfLife/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace GameOfLife;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Apps/PointOfSale/src/PointOfSale/Platforms/Android/MainActivity.cs
+++ b/9.0/Apps/PointOfSale/src/PointOfSale/Platforms/Android/MainActivity.cs
@@ -7,7 +7,7 @@ using PointOfSale.Data;
 
 namespace PointOfSale;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
 public class MainActivity : MauiAppCompatActivity
 {
     protected override void OnCreate(Bundle savedInstanceState)

--- a/9.0/Apps/WeatherTwentyOne/src/WeatherTwentyOne/Platforms/Android/MainActivity.cs
+++ b/9.0/Apps/WeatherTwentyOne/src/WeatherTwentyOne/Platforms/Android/MainActivity.cs
@@ -7,7 +7,7 @@ namespace WeatherTwentyOne;
 [IntentFilter(
     new[] { Platform.Intent.ActionAppAction },
 	Categories = new[] { Android.Content.Intent.CategoryDefault })]
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
 public class MainActivity : MauiAppCompatActivity
 {
     protected override void OnCreate(Bundle savedInstanceState)

--- a/9.0/Apps/WordPuzzle/WordPuzzle/Platforms/Android/MainActivity.cs
+++ b/9.0/Apps/WordPuzzle/WordPuzzle/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace WordPuzzle
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/9.0/Beginners-Series/BeginnersTask/Platforms/Android/MainActivity.cs
+++ b/9.0/Beginners-Series/BeginnersTask/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace BeginnersTasks;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Data/TodoSQLite/TodoSQLite/Platforms/Android/MainActivity.cs
+++ b/9.0/Data/TodoSQLite/TodoSQLite/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TodoSQLite;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Fundamentals/BehaviorsDemos/BehaviorsDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/Fundamentals/BehaviorsDemos/BehaviorsDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace BehaviorsDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Fundamentals/ContextMenu/ContextMenuSample/Platforms/Android/MainActivity.cs
+++ b/9.0/Fundamentals/ContextMenu/ContextMenuSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ContextMenuSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Fundamentals/ControlTemplateDemos/ControlTemplateDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/Fundamentals/ControlTemplateDemos/ControlTemplateDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ControlTemplateDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Fundamentals/DataBindingDemos/DataBindingDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/Fundamentals/DataBindingDemos/DataBindingDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace DataBindingDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Fundamentals/DataTemplateDemos/DataTemplates/Platforms/Android/MainActivity.cs
+++ b/9.0/Fundamentals/DataTemplateDemos/DataTemplates/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace DataTemplates;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Fundamentals/Localization/LocalizationDemo/Platforms/Android/MainActivity.cs
+++ b/9.0/Fundamentals/Localization/LocalizationDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace LocalizationDemo
 {
-    [Activity(Label = "@string/app_name", Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Label = "@string/app_name", Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
         protected override void OnCreate(Bundle savedInstanceState)

--- a/9.0/Fundamentals/Shell/Xaminals/Platforms/Android/MainActivity.cs
+++ b/9.0/Fundamentals/Shell/Xaminals/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Xaminals;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Fundamentals/Tooltips/TooltipsSample/Platforms/Android/MainActivity.cs
+++ b/9.0/Fundamentals/Tooltips/TooltipsSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TooltipsSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Fundamentals/TriggersDemos/WorkingWithTriggers/Platforms/Android/MainActivity.cs
+++ b/9.0/Fundamentals/TriggersDemos/WorkingWithTriggers/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace WorkingWithTriggers;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Navigation/FlyoutPageSample/FlyoutPageSample/Platforms/Android/MainActivity.cs
+++ b/9.0/Navigation/FlyoutPageSample/FlyoutPageSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace FlyoutPageSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Navigation/ShellFlyoutSample/ShellFlyoutSample/Platforms/Android/MainActivity.cs
+++ b/9.0/Navigation/ShellFlyoutSample/ShellFlyoutSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ShellFlyoutSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Navigation/ShellMixedSample/ShellMixedSample/Platforms/Android/MainActivity.cs
+++ b/9.0/Navigation/ShellMixedSample/ShellMixedSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ShellMixedSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Navigation/ShellTabBarSample/ShellTabBarSample/Platforms/Android/MainActivity.cs
+++ b/9.0/Navigation/ShellTabBarSample/ShellTabBarSample/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ShellTabBarSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Navigation/TabbedPage/TabbedPage/Platforms/Android/MainActivity.cs
+++ b/9.0/Navigation/TabbedPage/TabbedPage/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TabbedPageSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/PlatformIntegration/InvokePlatformCodeDemos/InvokePlatformCodeDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/PlatformIntegration/InvokePlatformCodeDemos/InvokePlatformCodeDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace InvokePlatformCodeDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/PlatformIntegration/NativeEmbeddingDemo/NativeEmbeddingDemo.Droid/MainActivity.cs
+++ b/9.0/PlatformIntegration/NativeEmbeddingDemo/NativeEmbeddingDemo.Droid/MainActivity.cs
@@ -8,7 +8,7 @@ using Toolbar = AndroidX.AppCompat.Widget.Toolbar;
 
 namespace NativeEmbeddingDemo.Droid
 {
-    [Activity(Label = "@string/app_name", MainLauncher = true, Theme = "@style/Theme.MyApplication")]
+    [Activity(Label = "@string/app_name", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, Theme = "@style/Theme.MyApplication")]
     public class MainActivity : AppCompatActivity
     {
         AppBarConfiguration? appBarConfiguration;

--- a/9.0/PlatformIntegration/NativeEmbeddingDemo/TestHarnessApp/Platforms/Android/MainActivity.cs
+++ b/9.0/PlatformIntegration/NativeEmbeddingDemo/TestHarnessApp/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TestHarnessApp;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/PlatformIntegration/PlatformIntegrationDemos/PlatformIntegrationDemo/Platforms/Android/MainActivity.cs
+++ b/9.0/PlatformIntegration/PlatformIntegrationDemos/PlatformIntegrationDemo/Platforms/Android/MainActivity.cs
@@ -6,7 +6,7 @@ using Android.Widget;
 
 namespace PlatformIntegrationDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density, ScreenOrientation = ScreenOrientation.FullSensor)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density, ScreenOrientation = ScreenOrientation.FullSensor)]
 [IntentFilter(
         new[] { Microsoft.Maui.ApplicationModel.Platform.Intent.ActionAppAction },
         Categories = new[] { Intent.CategoryDefault })]

--- a/9.0/SkiaSharp/MandelbrotAnimation/MandelbrotAnimation/Platforms/Android/MainActivity.cs
+++ b/9.0/SkiaSharp/MandelbrotAnimation/MandelbrotAnimation/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MandelbrotAnimation;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/SkiaSharp/PhotoPuzzle/PhotoPuzzle/Platforms/Android/MainActivity.cs
+++ b/9.0/SkiaSharp/PhotoPuzzle/PhotoPuzzle/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace PhotoPuzzle;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/SkiaSharp/SkiaSharpDemos/SkiaSharpDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/SkiaSharp/SkiaSharpDemos/SkiaSharpDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace SkiaSharpDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/SkiaSharp/SpinPaint/SpinPaint/Platforms/Android/MainActivity.cs
+++ b/9.0/SkiaSharp/SpinPaint/SpinPaint/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace SpinPaint;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/Tutorials/ConvertToMvvm/code/Platforms/Android/MainActivity.cs
+++ b/9.0/Tutorials/ConvertToMvvm/code/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Notes
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/9.0/Tutorials/CreateNetMauiApp/code/Platforms/Android/MainActivity.cs
+++ b/9.0/Tutorials/CreateNetMauiApp/code/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Notes
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/9.0/UITesting/BasicAppiumNunitSample/MauiApp/Platforms/Android/MainActivity.cs
+++ b/9.0/UITesting/BasicAppiumNunitSample/MauiApp/Platforms/Android/MainActivity.cs
@@ -5,7 +5,7 @@ using Android.Runtime;
 
 namespace BasicAppiumSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 [Register("com.companyname.basicappiumsample.MainActivity")]
 public class MainActivity : MauiAppCompatActivity
 {

--- a/9.0/UITesting/BrowserStackAppiumMaui/BasicAppiumNunitSample/MauiApp/Platforms/Android/MainActivity.cs
+++ b/9.0/UITesting/BrowserStackAppiumMaui/BasicAppiumNunitSample/MauiApp/Platforms/Android/MainActivity.cs
@@ -5,7 +5,7 @@ using Android.Runtime;
 
 namespace BasicAppiumSample;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 [Register("com.companyname.basicappiumsample.MainActivity")]
 public class MainActivity : MauiAppCompatActivity
 {

--- a/9.0/UserInterface/BrushesDemos/BrushesDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/BrushesDemos/BrushesDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace BrushesDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/ControlGallery/ControlGallery/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/ControlGallery/ControlGallery/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ControlGallery;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Handlers/CreateHandlerDemo/VideoDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Handlers/CreateHandlerDemo/VideoDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace VideoDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Handlers/CustomizeHandlersDemo/CustomizeHandlersDemo/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Handlers/CustomizeHandlersDemo/CustomizeHandlersDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace CustomizeHandlersDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/HyperlinkDemo/HyperlinkDemo/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/HyperlinkDemo/HyperlinkDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace HyperlinkDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Layouts/AbsoluteLayoutDemos/AbsoluteLayoutDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Layouts/AbsoluteLayoutDemos/AbsoluteLayoutDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace AbsoluteLayoutDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Layouts/BindableLayoutDemos/BindableLayoutDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Layouts/BindableLayoutDemos/BindableLayoutDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace BindableLayoutDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Layouts/CustomLayoutDemos/CustomLayoutDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Layouts/CustomLayoutDemos/CustomLayoutDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace CustomLayoutDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Layouts/FlexLayoutDemos/FlexLayoutDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Layouts/FlexLayoutDemos/FlexLayoutDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace FlexLayoutDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Layouts/GridDemos/GridDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Layouts/GridDemos/GridDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace GridDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Layouts/StackLayoutDemos/StackLayoutDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Layouts/StackLayoutDemos/StackLayoutDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace StackLayoutDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/SystemThemesDemo/SystemThemesDemo/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/SystemThemesDemo/SystemThemesDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace SystemThemesDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/ThemingDemo/ThemingDemo/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/ThemingDemo/ThemingDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ThemingDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/CarouselViewDemos/CarouselViewDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/CarouselViewDemos/CarouselViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace CarouselViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/CheckBoxDemos/CheckBoxDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/CheckBoxDemos/CheckBoxDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace CheckBoxDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace CollectionViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/GraphicsViewDemos/GraphicsViewDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/GraphicsViewDemos/GraphicsViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace GraphicsViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/IndicatorViewDemos/IndicatorViewDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/IndicatorViewDemos/IndicatorViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace IndicatorViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/ListViewDemos/ListViewDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/ListViewDemos/ListViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ListViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/Map/MapDemo/WorkingWithMaps/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/Map/MapDemo/WorkingWithMaps/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace WorkingWithMaps;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/RadioButtonDemos/RadioButtonDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/RadioButtonDemos/RadioButtonDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace RadioButtonDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/RefreshViewDemo/RefreshViewDemo/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/RefreshViewDemo/RefreshViewDemo/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace RefreshViewDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/ScrollViewDemos/ScrollViewDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/ScrollViewDemos/ScrollViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ScrollViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/ShapesDemos/ShapesDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/ShapesDemos/ShapesDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace ShapesDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/SwipeViewDemos/SwipeViewDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/SwipeViewDemos/SwipeViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace SwipeViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/SwitchDemos/SwitchDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/SwitchDemos/SwitchDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace SwitchDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/TableViewDemos/TableViewDemos/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/TableViewDemos/TableViewDemos/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TableViewDemos;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/Views/TwoPaneView/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/Views/TwoPaneView/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MauiTwoPaneViewDemo;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/WorkingWithColors/WorkingWithColors/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/WorkingWithColors/WorkingWithColors/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace WorkingWithColors;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/UserInterface/WorkingWithFiles/WorkingWithFiles/Platforms/Android/MainActivity.cs
+++ b/9.0/UserInterface/WorkingWithFiles/WorkingWithFiles/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace WorkingWithFiles;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/WebServices/TodoREST/TodoREST/Platforms/Android/MainActivity.cs
+++ b/9.0/WebServices/TodoREST/TodoREST/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace TodoREST;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/XAML/Fundamentals/XamlSamples/Platforms/Android/MainActivity.cs
+++ b/9.0/XAML/Fundamentals/XamlSamples/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace XamlSamples;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/9.0/XAML/MarkupExtensions/MarkupExtensions/Platforms/Android/MainActivity.cs
+++ b/9.0/XAML/MarkupExtensions/MarkupExtensions/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MarkupExtensions;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/Upgrading/CustomRenderer/MauiCustomRenderer/Platforms/Android/MainActivity.cs
+++ b/Upgrading/CustomRenderer/MauiCustomRenderer/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MauiCustomRenderer;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/Upgrading/CustomRenderer/MultiProject/Entry/Android/MainActivity.cs
+++ b/Upgrading/CustomRenderer/MultiProject/Entry/Android/MainActivity.cs
@@ -13,8 +13,8 @@ using Microsoft.Maui.Controls;
 
 namespace CustomRenderer.Android
 {
-	[Activity (Label = "CustomRenderer.Android.Android", Icon = "@drawable/icon", 
-		Theme = "@style/MainTheme", MainLauncher = true, 
+	[Activity (Label = "CustomRenderer.Android.Android", Icon = "@drawable/icon",
+		Theme = "@style/MainTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop,
 		ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
 	public class MainActivity : MauiAppCompatActivity
 	{

--- a/Upgrading/CustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer.Android/MainActivity.cs
+++ b/Upgrading/CustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer.Android/MainActivity.cs
@@ -7,7 +7,7 @@ using Android.OS;
 
 namespace XamarinCustomRenderer.Droid
 {
-    [Activity(Label = "XamarinCustomRenderer", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize )]
+    [Activity(Label = "XamarinCustomRenderer", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize )]
     public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
         protected override void OnCreate(Bundle savedInstanceState)


### PR DESCRIPTION
## Description
All `MainActivity.cs` files that didn’t have `LaunchMode.SingleTop` have been updated. This prevents multiple instances of the activity when the app is reopened from the launcher and ensures a clean activity stack.