### PR TITLE
Add tooltip text for Add buttons in Developer Balance sample

### DIFF
--- a/10.0/Apps/DeveloperBalance/Pages/MainPage.xaml
+++ b/10.0/Apps/DeveloperBalance/Pages/MainPage.xaml
@@ -97,6 +97,7 @@
         <controls:AddButton 
             IsEnabled="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
             Command="{Binding AddTaskCommand}"
+            ToolTipProperties.Text="Add task"
             SemanticProperties.Description="Add task" />
     </Grid>
 </ContentPage>

--- a/10.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
+++ b/10.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
@@ -184,7 +184,8 @@
         </ScrollView>
 
         <controls:AddButton Command="{Binding AddTaskCommand}" 
-                            SemanticProperties.Description="Add task" />
+                            SemanticProperties.Description="Add task" 
+                            ToolTipProperties.Text="Add task" />
     </Grid>
     
 </ContentPage>

--- a/10.0/Apps/DeveloperBalance/Pages/ProjectListPage.xaml
+++ b/10.0/Apps/DeveloperBalance/Pages/ProjectListPage.xaml
@@ -44,6 +44,8 @@
         </CollectionView>
 
         <controls:AddButton
-        Command="{Binding AddProjectCommand}" />
+        Command="{Binding AddProjectCommand}"
+        SemanticProperties.Description="Add project"  
+        ToolTipProperties.Text="Add Project" />
     </Grid>
 </ContentPage>

--- a/9.0/Apps/DeveloperBalance/Pages/MainPage.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/MainPage.xaml
@@ -96,7 +96,8 @@
 
         <controls:AddButton 
             IsEnabled="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-            Command="{Binding AddTaskCommand}" 
+            Command="{Binding AddTaskCommand}"
+            ToolTipProperties.Text="Add task" 
             SemanticProperties.Description="Add task" />
     </Grid>
 </ContentPage>

--- a/9.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
@@ -184,7 +184,8 @@
         </ScrollView>
 
         <controls:AddButton Command="{Binding AddTaskCommand}" 
-                            SemanticProperties.Description="Add task" />
+                            SemanticProperties.Description="Add task" 
+                            ToolTipProperties.Text="Add task" />
     </Grid>
     
 </ContentPage>

--- a/9.0/Apps/DeveloperBalance/Pages/ProjectListPage.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/ProjectListPage.xaml
@@ -44,6 +44,7 @@
 
         <controls:AddButton
             Command="{Binding AddProjectCommand}" 
-            SemanticProperties.Description="Add project" />
+            SemanticProperties.Description="Add project" 
+            ToolTipProperties.Text="Add project" />
     </Grid>
 </ContentPage>


### PR DESCRIPTION
### Issue Details
No tooltip was shown for the Add Button in the Developer Balance sample. 

### Description of Change
Added tooltip text for the Add buttons in the Project and Tasks sections.

MAUI Issue report: https://github.com/dotnet/maui/issues/30810

### Screenshots

| Mac | Windows |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/345e5754-01b1-49d6-8a76-84cb478a9e05"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/88d28356-ee17-47ec-b2df-6f826fc89ab8">) |