### PR TITLE
Remove SemanticProperties.Description from CollectionView

### DIFF
--- a/10.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
+++ b/10.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
@@ -109,8 +109,7 @@
                     Margin="0,0,0,15"
                     SelectedItems="{Binding SelectedTags, Mode=TwoWay}"
                     SelectionChangedCommand="{Binding SelectionChangedCommand}"
-                    SelectionChangedCommandParameter="{Binding SelectedTags}"
-                    SemanticProperties.Description="Tags Collection">
+                    SelectionChangedCommandParameter="{Binding SelectedTags}">
                     <CollectionView.ItemsLayout>
                         <LinearItemsLayout Orientation="Horizontal" ItemSpacing="{StaticResource LayoutSpacing}" />
                     </CollectionView.ItemsLayout>


### PR DESCRIPTION
**Accessibility note (iOS / VoiceOver)**
While investigating this issue, it’s worth noting that setting IsAccessibilityElement = true on the UIViewControllerWrapperView causes VoiceOver to treat the wrapper as a single accessibility element. As a result, all child elements (including individual cells) are no longer exposed to the accessibility tree.

This is expected UIKit behavior:
An accessibility element replaces its children in the VoiceOver hierarchy.

Therefore, I've removed the `SemanticProperties.Description="Tags Collection"`

Fixes https://github.com/dotnet/maui/issues/30891
Fixes https://github.com/dotnet/maui/issues/30749


<video src="https://github.com/user-attachments/assets/c7b94b6f-b98b-4efb-b242-5af240f7c606"/>