### PR TITLE
Add .NET 11 SDK to CI build workflows

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -22,6 +22,7 @@ jobs:
         dotnet-version: |
           9.0.x
           10.0.x
+          11.0.x
         include-prerelease: true
         dotnet-quality: 'preview'
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,6 +26,7 @@ jobs:
         dotnet-version: |
           9.0.x
           10.0.x
+          11.0.x
         include-prerelease: true
         dotnet-quality: 'preview'
 


### PR DESCRIPTION
Include `11.0.x` in the `dotnet-version` list for both `build-all` and `build-pr` workflows so that `net11.0-*` sample projects can be built in CI.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>