### PR TITLE
Fix Race conditions, thread-safety issues, and code quality in Developer Balance sample

### DIFF
--- a/10.0/Apps/DeveloperBalance/AppShell.xaml.cs
+++ b/10.0/Apps/DeveloperBalance/AppShell.xaml.cs
@@ -16,7 +16,7 @@ public partial class AppShell : Shell
 	}
 	public static async Task DisplaySnackbarAsync(string message)
 	{
-		CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+		using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
 		var snackbarOptions = new SnackbarOptions
 		{
@@ -41,7 +41,7 @@ public partial class AppShell : Shell
 
 		var toast = Toast.Make(message, textSize: 18);
 
-		var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 		await toast.Show(cts.Token);
 	}
 

--- a/10.0/Apps/DeveloperBalance/Data/CategoryRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/CategoryRepository.cs
@@ -183,14 +183,22 @@ public class CategoryRepository
 	/// </summary>
 	public async Task DropTableAsync()
 	{
-		await Init();
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
+		await _initLock.WaitAsync();
+		try
+		{
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
 
-		var dropTableCmd = connection.CreateCommand();
-		dropTableCmd.CommandText = "DROP TABLE IF EXISTS Category";
+			var dropTableCmd = connection.CreateCommand();
+			dropTableCmd.CommandText = "DROP TABLE IF EXISTS Category";
 
-		await dropTableCmd.ExecuteNonQueryAsync();
-		_hasBeenInitialized = false;
+			await dropTableCmd.ExecuteNonQueryAsync();
+
+			_hasBeenInitialized = false;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 }

--- a/10.0/Apps/DeveloperBalance/Data/CategoryRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/CategoryRepository.cs
@@ -10,6 +10,7 @@ namespace DeveloperBalance.Data;
 public class CategoryRepository
 {
 	private bool _hasBeenInitialized = false;
+	private readonly SemaphoreSlim _initLock = new(1, 1);
 	private readonly ILogger _logger;
 
 	/// <summary>
@@ -29,27 +30,38 @@ public class CategoryRepository
 		if (_hasBeenInitialized)
 			return;
 
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
-
+		await _initLock.WaitAsync();
 		try
 		{
-			var createTableCmd = connection.CreateCommand();
-			createTableCmd.CommandText = @"
+			if (_hasBeenInitialized)
+				return;
+
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
+
+			try
+			{
+				var createTableCmd = connection.CreateCommand();
+				createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Category (
                 ID INTEGER PRIMARY KEY AUTOINCREMENT,
                 Title TEXT NOT NULL,
                 Color TEXT NOT NULL
             );";
-			await createTableCmd.ExecuteNonQueryAsync();
-		}
-		catch (Exception e)
-		{
-			_logger.LogError(e, "Error creating Category table");
-			throw;
-		}
+				await createTableCmd.ExecuteNonQueryAsync();
+			}
+			catch (Exception e)
+			{
+				_logger.LogError(e, "Error creating Category table");
+				throw;
+			}
 
-		_hasBeenInitialized = true;
+			_hasBeenInitialized = true;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 
 	/// <summary>

--- a/10.0/Apps/DeveloperBalance/Data/CategoryRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/CategoryRepository.cs
@@ -39,24 +39,21 @@ public class CategoryRepository
 			await using var connection = new SqliteConnection(Constants.DatabasePath);
 			await connection.OpenAsync();
 
-			try
-			{
-				var createTableCmd = connection.CreateCommand();
-				createTableCmd.CommandText = @"
+			var createTableCmd = connection.CreateCommand();
+			createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Category (
                 ID INTEGER PRIMARY KEY AUTOINCREMENT,
                 Title TEXT NOT NULL,
                 Color TEXT NOT NULL
             );";
-				await createTableCmd.ExecuteNonQueryAsync();
-			}
-			catch (Exception e)
-			{
-				_logger.LogError(e, "Error creating Category table");
-				throw;
-			}
+			await createTableCmd.ExecuteNonQueryAsync();
 
 			_hasBeenInitialized = true;
+		}
+		catch (Exception e)
+		{
+			_logger.LogError(e, "Error creating Category table");
+			throw;
 		}
 		finally
 		{

--- a/10.0/Apps/DeveloperBalance/Data/JsonContext.cs
+++ b/10.0/Apps/DeveloperBalance/Data/JsonContext.cs
@@ -1,6 +1,8 @@
 using System.Text.Json.Serialization;
 using DeveloperBalance.Models;
 
+namespace DeveloperBalance.Data;
+
 [JsonSerializable(typeof(Project))]
 [JsonSerializable(typeof(ProjectTask))]
 [JsonSerializable(typeof(ProjectsJson))]

--- a/10.0/Apps/DeveloperBalance/Data/ProjectRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/ProjectRepository.cs
@@ -10,6 +10,7 @@ namespace DeveloperBalance.Data;
 public class ProjectRepository
 {
 	private bool _hasBeenInitialized = false;
+	private readonly SemaphoreSlim _initLock = new(1, 1);
 	private readonly ILogger _logger;
 	private readonly TaskRepository _taskRepository;
 	private readonly TagRepository _tagRepository;
@@ -35,13 +36,19 @@ public class ProjectRepository
 		if (_hasBeenInitialized)
 			return;
 
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
-
+		await _initLock.WaitAsync();
 		try
 		{
-			var createTableCmd = connection.CreateCommand();
-			createTableCmd.CommandText = @"
+			if (_hasBeenInitialized)
+				return;
+
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
+
+			try
+			{
+				var createTableCmd = connection.CreateCommand();
+				createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Project (
                 ID INTEGER PRIMARY KEY AUTOINCREMENT,
                 Name TEXT NOT NULL,
@@ -49,15 +56,20 @@ public class ProjectRepository
                 Icon TEXT NOT NULL,
                 CategoryID INTEGER NOT NULL
             );";
-			await createTableCmd.ExecuteNonQueryAsync();
-		}
-		catch (Exception e)
-		{
-			_logger.LogError(e, "Error creating Project table");
-			throw;
-		}
+				await createTableCmd.ExecuteNonQueryAsync();
+			}
+			catch (Exception e)
+			{
+				_logger.LogError(e, "Error creating Project table");
+				throw;
+			}
 
-		_hasBeenInitialized = true;
+			_hasBeenInitialized = true;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 
 	/// <summary>
@@ -87,10 +99,19 @@ public class ProjectRepository
 			});
 		}
 
+		// Fetch all tasks and all tags in one query each, then assign in memory.
+		// This reduces 2N+1 queries to 3 regardless of project count.
+		var allTasks = await _taskRepository.ListAsync();
+		var allTagsByProject = await _tagRepository.ListAllByProjectAsync();
+
+		var tasksByProject = allTasks
+			.GroupBy(t => t.ProjectID)
+			.ToDictionary(g => g.Key, g => g.ToList());
+
 		foreach (var project in projects)
 		{
-			project.Tags = await _tagRepository.ListAsync(project.ID);
-			project.Tasks = await _taskRepository.ListAsync(project.ID);
+			project.Tasks = tasksByProject.TryGetValue(project.ID, out var tasks) ? tasks : [];
+			project.Tags = allTagsByProject.TryGetValue(project.ID, out var tags) ? tags : [];
 		}
 
 		return projects;

--- a/10.0/Apps/DeveloperBalance/Data/ProjectRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/ProjectRepository.cs
@@ -45,10 +45,8 @@ public class ProjectRepository
 			await using var connection = new SqliteConnection(Constants.DatabasePath);
 			await connection.OpenAsync();
 
-			try
-			{
-				var createTableCmd = connection.CreateCommand();
-				createTableCmd.CommandText = @"
+			var createTableCmd = connection.CreateCommand();
+			createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Project (
                 ID INTEGER PRIMARY KEY AUTOINCREMENT,
                 Name TEXT NOT NULL,
@@ -56,15 +54,14 @@ public class ProjectRepository
                 Icon TEXT NOT NULL,
                 CategoryID INTEGER NOT NULL
             );";
-				await createTableCmd.ExecuteNonQueryAsync();
-			}
-			catch (Exception e)
-			{
-				_logger.LogError(e, "Error creating Project table");
-				throw;
-			}
+			await createTableCmd.ExecuteNonQueryAsync();
 
 			_hasBeenInitialized = true;
+		}
+		catch (Exception e)
+		{
+			_logger.LogError(e, "Error creating Project table");
+			throw;
 		}
 		finally
 		{

--- a/10.0/Apps/DeveloperBalance/Data/ProjectRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/ProjectRepository.cs
@@ -218,16 +218,24 @@ public class ProjectRepository
 	/// </summary>
 	public async Task DropTableAsync()
 	{
-		await Init();
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
+		await _initLock.WaitAsync();
+		try
+		{
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
 
-		var dropCmd = connection.CreateCommand();
-		dropCmd.CommandText = "DROP TABLE IF EXISTS Project";
-		await dropCmd.ExecuteNonQueryAsync();
+			var dropCmd = connection.CreateCommand();
+			dropCmd.CommandText = "DROP TABLE IF EXISTS Project";
+			await dropCmd.ExecuteNonQueryAsync();
+
+			_hasBeenInitialized = false;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 
 		await _taskRepository.DropTableAsync();
 		await _tagRepository.DropTableAsync();
-		_hasBeenInitialized = false;
 	}
 }

--- a/10.0/Apps/DeveloperBalance/Data/SeedDataService.cs
+++ b/10.0/Apps/DeveloperBalance/Data/SeedDataService.cs
@@ -24,7 +24,7 @@ public class SeedDataService
 
 	public async Task LoadSeedDataAsync()
 	{
-		ClearTables();
+		await ClearTables();
 
 		await using Stream templateStream = await FileSystem.OpenAppPackageFileAsync(_seedDataFilePath);
 
@@ -83,19 +83,9 @@ public class SeedDataService
 		}
 	}
 
-	private async void ClearTables()
+	private async Task ClearTables()
 	{
-		try
-		{
-			await Task.WhenAll(
-				_projectRepository.DropTableAsync(),
-				_taskRepository.DropTableAsync(),
-				_tagRepository.DropTableAsync(),
-				_categoryRepository.DropTableAsync());
-		}
-		catch (Exception e)
-		{
-			Console.WriteLine(e);
-		}
+		await _projectRepository.DropTableAsync();
+		await _categoryRepository.DropTableAsync();
 	}
 }

--- a/10.0/Apps/DeveloperBalance/Data/TagRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/TagRepository.cs
@@ -39,32 +39,29 @@ public class TagRepository
 			await using var connection = new SqliteConnection(Constants.DatabasePath);
 			await connection.OpenAsync();
 
-			try
-			{
-				var createTableCmd = connection.CreateCommand();
-				createTableCmd.CommandText = @"
+			var createTableCmd = connection.CreateCommand();
+			createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Tag (
                 ID INTEGER PRIMARY KEY AUTOINCREMENT,
                 Title TEXT NOT NULL,
                 Color TEXT NOT NULL
             );";
-				await createTableCmd.ExecuteNonQueryAsync();
+			await createTableCmd.ExecuteNonQueryAsync();
 
-				createTableCmd.CommandText = @"
+			createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS ProjectsTags (
                 ProjectID INTEGER NOT NULL,
                 TagID INTEGER NOT NULL,
                 PRIMARY KEY(ProjectID, TagID)
             );";
-				await createTableCmd.ExecuteNonQueryAsync();
-			}
-			catch (Exception e)
-			{
-				_logger.LogError(e, "Error creating tables");
-				throw;
-			}
+			await createTableCmd.ExecuteNonQueryAsync();
 
 			_hasBeenInitialized = true;
+		}
+		catch (Exception e)
+		{
+			_logger.LogError(e, "Error creating tables");
+			throw;
 		}
 		finally
 		{
@@ -346,12 +343,12 @@ public class TagRepository
 			await using var connection = new SqliteConnection(Constants.DatabasePath);
 			await connection.OpenAsync();
 
-		var dropTableCmd = connection.CreateCommand();
-		dropTableCmd.CommandText = "DROP TABLE IF EXISTS Tag";
-		await dropTableCmd.ExecuteNonQueryAsync();
+			var dropTableCmd = connection.CreateCommand();
+			dropTableCmd.CommandText = "DROP TABLE IF EXISTS Tag";
+			await dropTableCmd.ExecuteNonQueryAsync();
 
-		dropTableCmd.CommandText = "DROP TABLE IF EXISTS ProjectsTags";
-		await dropTableCmd.ExecuteNonQueryAsync();
+			dropTableCmd.CommandText = "DROP TABLE IF EXISTS ProjectsTags";
+			await dropTableCmd.ExecuteNonQueryAsync();
 
 			_hasBeenInitialized = false;
 		}

--- a/10.0/Apps/DeveloperBalance/Data/TagRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/TagRepository.cs
@@ -340,9 +340,11 @@ public class TagRepository
 	/// </summary>
 	public async Task DropTableAsync()
 	{
-		await Init();
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
+		await _initLock.WaitAsync();
+		try
+		{
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
 
 		var dropTableCmd = connection.CreateCommand();
 		dropTableCmd.CommandText = "DROP TABLE IF EXISTS Tag";
@@ -351,6 +353,11 @@ public class TagRepository
 		dropTableCmd.CommandText = "DROP TABLE IF EXISTS ProjectsTags";
 		await dropTableCmd.ExecuteNonQueryAsync();
 
-		_hasBeenInitialized = false;
+			_hasBeenInitialized = false;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 }

--- a/10.0/Apps/DeveloperBalance/Data/TagRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/TagRepository.cs
@@ -10,6 +10,7 @@ namespace DeveloperBalance.Data;
 public class TagRepository
 {
 	private bool _hasBeenInitialized = false;
+	private readonly SemaphoreSlim _initLock = new(1, 1);
 	private readonly ILogger _logger;
 
 	/// <summary>
@@ -29,35 +30,46 @@ public class TagRepository
 		if (_hasBeenInitialized)
 			return;
 
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
-
+		await _initLock.WaitAsync();
 		try
 		{
-			var createTableCmd = connection.CreateCommand();
-			createTableCmd.CommandText = @"
+			if (_hasBeenInitialized)
+				return;
+
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
+
+			try
+			{
+				var createTableCmd = connection.CreateCommand();
+				createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Tag (
                 ID INTEGER PRIMARY KEY AUTOINCREMENT,
                 Title TEXT NOT NULL,
                 Color TEXT NOT NULL
             );";
-			await createTableCmd.ExecuteNonQueryAsync();
+				await createTableCmd.ExecuteNonQueryAsync();
 
-			createTableCmd.CommandText = @"
+				createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS ProjectsTags (
                 ProjectID INTEGER NOT NULL,
                 TagID INTEGER NOT NULL,
                 PRIMARY KEY(ProjectID, TagID)
             );";
-			await createTableCmd.ExecuteNonQueryAsync();
-		}
-		catch (Exception e)
-		{
-			_logger.LogError(e, "Error creating tables");
-			throw;
-		}
+				await createTableCmd.ExecuteNonQueryAsync();
+			}
+			catch (Exception e)
+			{
+				_logger.LogError(e, "Error creating tables");
+				throw;
+			}
 
-		_hasBeenInitialized = true;
+			_hasBeenInitialized = true;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 
 	/// <summary>
@@ -89,6 +101,46 @@ public class TagRepository
 	}
 
 	/// <summary>
+	/// Retrieves all tags grouped by their associated project ID in a single query.
+	/// </summary>
+	/// <returns>A dictionary mapping project ID to its list of <see cref="Tag"/> objects.</returns>
+	public async Task<Dictionary<int, List<Tag>>> ListAllByProjectAsync()
+	{
+		await Init();
+		await using var connection = new SqliteConnection(Constants.DatabasePath);
+		await connection.OpenAsync();
+
+		var selectCmd = connection.CreateCommand();
+		selectCmd.CommandText = @"
+        SELECT t.ID, t.Title, t.Color, pt.ProjectID
+        FROM Tag t
+        JOIN ProjectsTags pt ON t.ID = pt.TagID";
+
+		var result = new Dictionary<int, List<Tag>>();
+
+		await using var reader = await selectCmd.ExecuteReaderAsync();
+		while (await reader.ReadAsync())
+		{
+			var tag = new Tag
+			{
+				ID = reader.GetInt32(0),
+				Title = reader.GetString(1),
+				Color = reader.GetString(2)
+			};
+			var projectID = reader.GetInt32(3);
+
+			if (!result.TryGetValue(projectID, out var list))
+			{
+				list = [];
+				result[projectID] = list;
+			}
+			list.Add(tag);
+		}
+
+		return result;
+	}
+
+	/// <summary>
 	/// Retrieves a list of tags associated with a specific project.
 	/// </summary>
 	/// <param name="projectID">The ID of the project.</param>
@@ -105,7 +157,7 @@ public class TagRepository
         FROM Tag t
         JOIN ProjectsTags pt ON t.ID = pt.TagID
         WHERE pt.ProjectID = @ProjectID";
-		selectCmd.Parameters.AddWithValue("ProjectID", projectID);
+		selectCmd.Parameters.AddWithValue("@ProjectID", projectID);
 
 		var tags = new List<Tag>();
 

--- a/10.0/Apps/DeveloperBalance/Data/TaskRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/TaskRepository.cs
@@ -10,6 +10,7 @@ namespace DeveloperBalance.Data;
 public class TaskRepository
 {
 	private bool _hasBeenInitialized = false;
+	private readonly SemaphoreSlim _initLock = new(1, 1);
 	private readonly ILogger _logger;
 
 	/// <summary>
@@ -29,28 +30,39 @@ public class TaskRepository
 		if (_hasBeenInitialized)
 			return;
 
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
-
+		await _initLock.WaitAsync();
 		try
 		{
-			var createTableCmd = connection.CreateCommand();
-			createTableCmd.CommandText = @"
+			if (_hasBeenInitialized)
+				return;
+
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
+
+			try
+			{
+				var createTableCmd = connection.CreateCommand();
+				createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Task (
                 ID INTEGER PRIMARY KEY AUTOINCREMENT,
                 Title TEXT NOT NULL,
                 IsCompleted INTEGER NOT NULL,
                 ProjectID INTEGER NOT NULL
             );";
-			await createTableCmd.ExecuteNonQueryAsync();
-		}
-		catch (Exception e)
-		{
-			_logger.LogError(e, "Error creating Task table");
-			throw;
-		}
+				await createTableCmd.ExecuteNonQueryAsync();
+			}
+			catch (Exception e)
+			{
+				_logger.LogError(e, "Error creating Task table");
+				throw;
+			}
 
-		_hasBeenInitialized = true;
+			_hasBeenInitialized = true;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 
 	/// <summary>

--- a/10.0/Apps/DeveloperBalance/Data/TaskRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/TaskRepository.cs
@@ -39,25 +39,22 @@ public class TaskRepository
 			await using var connection = new SqliteConnection(Constants.DatabasePath);
 			await connection.OpenAsync();
 
-			try
-			{
-				var createTableCmd = connection.CreateCommand();
-				createTableCmd.CommandText = @"
+			var createTableCmd = connection.CreateCommand();
+			createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Task (
                 ID INTEGER PRIMARY KEY AUTOINCREMENT,
                 Title TEXT NOT NULL,
                 IsCompleted INTEGER NOT NULL,
                 ProjectID INTEGER NOT NULL
             );";
-				await createTableCmd.ExecuteNonQueryAsync();
-			}
-			catch (Exception e)
-			{
-				_logger.LogError(e, "Error creating Task table");
-				throw;
-			}
+			await createTableCmd.ExecuteNonQueryAsync();
 
 			_hasBeenInitialized = true;
+		}
+		catch (Exception e)
+		{
+			_logger.LogError(e, "Error creating Task table");
+			throw;
 		}
 		finally
 		{

--- a/10.0/Apps/DeveloperBalance/Data/TaskRepository.cs
+++ b/10.0/Apps/DeveloperBalance/Data/TaskRepository.cs
@@ -216,13 +216,21 @@ public class TaskRepository
 	/// </summary>
 	public async Task DropTableAsync()
 	{
-		await Init();
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
+		await _initLock.WaitAsync();
+		try
+		{
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
 
-		var dropTableCmd = connection.CreateCommand();
-		dropTableCmd.CommandText = "DROP TABLE IF EXISTS Task";
-		await dropTableCmd.ExecuteNonQueryAsync();
-		_hasBeenInitialized = false;
+			var dropTableCmd = connection.CreateCommand();
+			dropTableCmd.CommandText = "DROP TABLE IF EXISTS Task";
+			await dropTableCmd.ExecuteNonQueryAsync();
+
+			_hasBeenInitialized = false;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 }

--- a/10.0/Apps/DeveloperBalance/Models/ProjectsTags.cs
+++ b/10.0/Apps/DeveloperBalance/Models/ProjectsTags.cs
@@ -1,8 +1,0 @@
-namespace DeveloperBalance.Models;
-
-public class ProjectsTags
-{
-	public int ID { get; set; }
-	public int ProjectID { get; set; }
-	public int TagID { get; set; }
-}

--- a/10.0/Apps/DeveloperBalance/PageModels/MainPageModel.cs
+++ b/10.0/Apps/DeveloperBalance/PageModels/MainPageModel.cs
@@ -152,8 +152,8 @@ public partial class MainPageModel : ObservableObject, IProjectTaskPageModel
 		=> Shell.Current.GoToAsync($"task");
 
 	[RelayCommand]
-	private Task? NavigateToProject(Project project)
-		=> project is null ? null : Shell.Current.GoToAsync($"project?id={project.ID}");
+	private Task NavigateToProject(Project project)
+		=> project is null ? Task.CompletedTask : Shell.Current.GoToAsync($"project?id={project.ID}");
 
 	[RelayCommand]
 	private Task NavigateToTask(ProjectTask task)

--- a/10.0/Apps/DeveloperBalance/PageModels/ProjectListPageModel.cs
+++ b/10.0/Apps/DeveloperBalance/PageModels/ProjectListPageModel.cs
@@ -28,8 +28,8 @@ public partial class ProjectListPageModel : ObservableObject
 	}
 
 	[RelayCommand]
-	Task? NavigateToProject(Project project)
-		=> project is null ? null : Shell.Current.GoToAsync($"project?id={project.ID}");
+	private Task NavigateToProject(Project project)
+		=> project is null ? Task.CompletedTask : Shell.Current.GoToAsync($"project?id={project.ID}");
 
 	[RelayCommand]
 	async Task AddProject()

--- a/9.0/Apps/DeveloperBalance/AppShell.xaml.cs
+++ b/9.0/Apps/DeveloperBalance/AppShell.xaml.cs
@@ -16,7 +16,7 @@ public partial class AppShell : Shell
 	}
 	public static async Task DisplaySnackbarAsync(string message)
 	{
-		CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+		using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
 		var snackbarOptions = new SnackbarOptions
 		{
@@ -41,7 +41,7 @@ public partial class AppShell : Shell
 
 		var toast = Toast.Make(message, textSize: 18);
 
-		var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 		await toast.Show(cts.Token);
 	}
 

--- a/9.0/Apps/DeveloperBalance/Data/CategoryRepository.cs
+++ b/9.0/Apps/DeveloperBalance/Data/CategoryRepository.cs
@@ -10,6 +10,7 @@ namespace DeveloperBalance.Data;
 public class CategoryRepository
 {
 	private bool _hasBeenInitialized = false;
+	private readonly SemaphoreSlim _initLock = new(1, 1);
 	private readonly ILogger _logger;
 
 	/// <summary>
@@ -29,11 +30,15 @@ public class CategoryRepository
 		if (_hasBeenInitialized)
 			return;
 
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
-
+		await _initLock.WaitAsync();
 		try
 		{
+			if (_hasBeenInitialized)
+				return;
+
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
+
 			var createTableCmd = connection.CreateCommand();
 			createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Category (
@@ -42,14 +47,18 @@ public class CategoryRepository
                 Color TEXT NOT NULL
             );";
 			await createTableCmd.ExecuteNonQueryAsync();
+
+			_hasBeenInitialized = true;
 		}
 		catch (Exception e)
 		{
 			_logger.LogError(e, "Error creating Category table");
 			throw;
 		}
-
-		_hasBeenInitialized = true;
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 
 	/// <summary>
@@ -171,14 +180,22 @@ public class CategoryRepository
 	/// </summary>
 	public async Task DropTableAsync()
 	{
-		await Init();
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
+		await _initLock.WaitAsync();
+		try
+		{
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
 
-		var dropTableCmd = connection.CreateCommand();
-		dropTableCmd.CommandText = "DROP TABLE IF EXISTS Category";
+			var dropTableCmd = connection.CreateCommand();
+			dropTableCmd.CommandText = "DROP TABLE IF EXISTS Category";
 
-		await dropTableCmd.ExecuteNonQueryAsync();
-		_hasBeenInitialized = false;
+			await dropTableCmd.ExecuteNonQueryAsync();
+
+			_hasBeenInitialized = false;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 }

--- a/9.0/Apps/DeveloperBalance/Data/JsonContext.cs
+++ b/9.0/Apps/DeveloperBalance/Data/JsonContext.cs
@@ -1,6 +1,8 @@
 using System.Text.Json.Serialization;
 using DeveloperBalance.Models;
 
+namespace DeveloperBalance.Data;
+
 [JsonSerializable(typeof(Project))]
 [JsonSerializable(typeof(ProjectTask))]
 [JsonSerializable(typeof(ProjectsJson))]

--- a/9.0/Apps/DeveloperBalance/Data/ProjectRepository.cs
+++ b/9.0/Apps/DeveloperBalance/Data/ProjectRepository.cs
@@ -10,6 +10,7 @@ namespace DeveloperBalance.Data;
 public class ProjectRepository
 {
 	private bool _hasBeenInitialized = false;
+	private readonly SemaphoreSlim _initLock = new(1, 1);
 	private readonly ILogger _logger;
 	private readonly TaskRepository _taskRepository;
 	private readonly TagRepository _tagRepository;
@@ -35,11 +36,15 @@ public class ProjectRepository
 		if (_hasBeenInitialized)
 			return;
 
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
-
+		await _initLock.WaitAsync();
 		try
 		{
+			if (_hasBeenInitialized)
+				return;
+
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
+
 			var createTableCmd = connection.CreateCommand();
 			createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Project (
@@ -50,14 +55,18 @@ public class ProjectRepository
                 CategoryID INTEGER NOT NULL
             );";
 			await createTableCmd.ExecuteNonQueryAsync();
+
+			_hasBeenInitialized = true;
 		}
 		catch (Exception e)
 		{
 			_logger.LogError(e, "Error creating Project table");
 			throw;
 		}
-
-		_hasBeenInitialized = true;
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 
 	/// <summary>
@@ -87,10 +96,19 @@ public class ProjectRepository
 			});
 		}
 
+		// Fetch all tasks and all tags in one query each, then assign in memory.
+		// This reduces 2N+1 queries to 3 regardless of project count.
+		var allTasks = await _taskRepository.ListAsync();
+		var allTagsByProject = await _tagRepository.ListAllByProjectAsync();
+
+		var tasksByProject = allTasks
+			.GroupBy(t => t.ProjectID)
+			.ToDictionary(g => g.Key, g => g.ToList());
+
 		foreach (var project in projects)
 		{
-			project.Tags = await _tagRepository.ListAsync(project.ID);
-			project.Tasks = await _taskRepository.ListAsync(project.ID);
+			project.Tasks = tasksByProject.TryGetValue(project.ID, out var tasks) ? tasks : [];
+			project.Tags = allTagsByProject.TryGetValue(project.ID, out var tags) ? tags : [];
 		}
 
 		return projects;
@@ -197,16 +215,24 @@ public class ProjectRepository
 	/// </summary>
 	public async Task DropTableAsync()
 	{
-		await Init();
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
+		await _initLock.WaitAsync();
+		try
+		{
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
 
-		var dropCmd = connection.CreateCommand();
-		dropCmd.CommandText = "DROP TABLE IF EXISTS Project";
-		await dropCmd.ExecuteNonQueryAsync();
+			var dropCmd = connection.CreateCommand();
+			dropCmd.CommandText = "DROP TABLE IF EXISTS Project";
+			await dropCmd.ExecuteNonQueryAsync();
+
+			_hasBeenInitialized = false;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 
 		await _taskRepository.DropTableAsync();
 		await _tagRepository.DropTableAsync();
-		_hasBeenInitialized = false;
 	}
 }

--- a/9.0/Apps/DeveloperBalance/Data/SeedDataService.cs
+++ b/9.0/Apps/DeveloperBalance/Data/SeedDataService.cs
@@ -24,7 +24,7 @@ public class SeedDataService
 
 	public async Task LoadSeedDataAsync()
 	{
-		ClearTables();
+		await ClearTables();
 
 		await using Stream templateStream = await FileSystem.OpenAppPackageFileAsync(_seedDataFilePath);
 
@@ -83,19 +83,9 @@ public class SeedDataService
 		}
 	}
 
-	private async void ClearTables()
+	private async Task ClearTables()
 	{
-		try
-		{
-			await Task.WhenAll(
-				_projectRepository.DropTableAsync(),
-				_taskRepository.DropTableAsync(),
-				_tagRepository.DropTableAsync(),
-				_categoryRepository.DropTableAsync());
-		}
-		catch (Exception e)
-		{
-			Console.WriteLine(e);
-		}
+		await _projectRepository.DropTableAsync();
+		await _categoryRepository.DropTableAsync();
 	}
 }

--- a/9.0/Apps/DeveloperBalance/Data/TagRepository.cs
+++ b/9.0/Apps/DeveloperBalance/Data/TagRepository.cs
@@ -10,6 +10,7 @@ namespace DeveloperBalance.Data;
 public class TagRepository
 {
 	private bool _hasBeenInitialized = false;
+	private readonly SemaphoreSlim _initLock = new(1, 1);
 	private readonly ILogger _logger;
 
 	/// <summary>
@@ -29,35 +30,46 @@ public class TagRepository
 		if (_hasBeenInitialized)
 			return;
 
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
-
+		await _initLock.WaitAsync();
 		try
 		{
-			var createTableCmd = connection.CreateCommand();
-			createTableCmd.CommandText = @"
+			if (_hasBeenInitialized)
+				return;
+
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
+
+			try
+			{
+				var createTableCmd = connection.CreateCommand();
+				createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Tag (
                 ID INTEGER PRIMARY KEY AUTOINCREMENT,
                 Title TEXT NOT NULL,
                 Color TEXT NOT NULL
             );";
-			await createTableCmd.ExecuteNonQueryAsync();
+				await createTableCmd.ExecuteNonQueryAsync();
 
-			createTableCmd.CommandText = @"
+				createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS ProjectsTags (
                 ProjectID INTEGER NOT NULL,
                 TagID INTEGER NOT NULL,
                 PRIMARY KEY(ProjectID, TagID)
             );";
-			await createTableCmd.ExecuteNonQueryAsync();
-		}
-		catch (Exception e)
-		{
-			_logger.LogError(e, "Error creating tables");
-			throw;
-		}
+				await createTableCmd.ExecuteNonQueryAsync();
+			}
+			catch (Exception e)
+			{
+				_logger.LogError(e, "Error creating tables");
+				throw;
+			}
 
-		_hasBeenInitialized = true;
+			_hasBeenInitialized = true;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 
 	/// <summary>
@@ -89,6 +101,46 @@ public class TagRepository
 	}
 
 	/// <summary>
+	/// Retrieves all tags grouped by their associated project ID in a single query.
+	/// </summary>
+	/// <returns>A dictionary mapping project ID to its list of <see cref="Tag"/> objects.</returns>
+	public async Task<Dictionary<int, List<Tag>>> ListAllByProjectAsync()
+	{
+		await Init();
+		await using var connection = new SqliteConnection(Constants.DatabasePath);
+		await connection.OpenAsync();
+
+		var selectCmd = connection.CreateCommand();
+		selectCmd.CommandText = @"
+			SELECT t.ID, t.Title, t.Color, pt.ProjectID
+			FROM Tag t
+			JOIN ProjectsTags pt ON t.ID = pt.TagID";
+
+		var result = new Dictionary<int, List<Tag>>();
+
+		await using var reader = await selectCmd.ExecuteReaderAsync();
+		while (await reader.ReadAsync())
+		{
+			var tag = new Tag
+			{
+				ID = reader.GetInt32(0),
+				Title = reader.GetString(1),
+				Color = reader.GetString(2)
+			};
+			var projectID = reader.GetInt32(3);
+
+			if (!result.TryGetValue(projectID, out var list))
+			{
+				list = [];
+				result[projectID] = list;
+			}
+			list.Add(tag);
+		}
+
+		return result;
+	}
+
+	/// <summary>
 	/// Retrieves a list of tags associated with a specific project.
 	/// </summary>
 	/// <param name="projectID">The ID of the project.</param>
@@ -105,7 +157,7 @@ public class TagRepository
         FROM Tag t
         JOIN ProjectsTags pt ON t.ID = pt.TagID
         WHERE pt.ProjectID = @ProjectID";
-		selectCmd.Parameters.AddWithValue("ProjectID", projectID);
+		selectCmd.Parameters.AddWithValue("@ProjectID", projectID);
 
 		var tags = new List<Tag>();
 
@@ -288,17 +340,24 @@ public class TagRepository
 	/// </summary>
 	public async Task DropTableAsync()
 	{
-		await Init();
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
+		await _initLock.WaitAsync();
+		try
+		{
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
 
-		var dropTableCmd = connection.CreateCommand();
-		dropTableCmd.CommandText = "DROP TABLE IF EXISTS Tag";
-		await dropTableCmd.ExecuteNonQueryAsync();
+			var dropTableCmd = connection.CreateCommand();
+			dropTableCmd.CommandText = "DROP TABLE IF EXISTS Tag";
+			await dropTableCmd.ExecuteNonQueryAsync();
 
-		dropTableCmd.CommandText = "DROP TABLE IF EXISTS ProjectsTags";
-		await dropTableCmd.ExecuteNonQueryAsync();
+			dropTableCmd.CommandText = "DROP TABLE IF EXISTS ProjectsTags";
+			await dropTableCmd.ExecuteNonQueryAsync();
 
-		_hasBeenInitialized = false;
+			_hasBeenInitialized = false;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 }

--- a/9.0/Apps/DeveloperBalance/Data/TaskRepository.cs
+++ b/9.0/Apps/DeveloperBalance/Data/TaskRepository.cs
@@ -10,6 +10,7 @@ namespace DeveloperBalance.Data;
 public class TaskRepository
 {
 	private bool _hasBeenInitialized = false;
+	private readonly SemaphoreSlim _initLock = new(1, 1);
 	private readonly ILogger _logger;
 
 	/// <summary>
@@ -29,11 +30,15 @@ public class TaskRepository
 		if (_hasBeenInitialized)
 			return;
 
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
-
+		await _initLock.WaitAsync();
 		try
 		{
+			if (_hasBeenInitialized)
+				return;
+
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
+
 			var createTableCmd = connection.CreateCommand();
 			createTableCmd.CommandText = @"
             CREATE TABLE IF NOT EXISTS Task (
@@ -43,14 +48,18 @@ public class TaskRepository
                 ProjectID INTEGER NOT NULL
             );";
 			await createTableCmd.ExecuteNonQueryAsync();
+
+			_hasBeenInitialized = true;
 		}
 		catch (Exception e)
 		{
 			_logger.LogError(e, "Error creating Task table");
 			throw;
 		}
-
-		_hasBeenInitialized = true;
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 
 	/// <summary>
@@ -204,13 +213,21 @@ public class TaskRepository
 	/// </summary>
 	public async Task DropTableAsync()
 	{
-		await Init();
-		await using var connection = new SqliteConnection(Constants.DatabasePath);
-		await connection.OpenAsync();
+		await _initLock.WaitAsync();
+		try
+		{
+			await using var connection = new SqliteConnection(Constants.DatabasePath);
+			await connection.OpenAsync();
 
-		var dropTableCmd = connection.CreateCommand();
-		dropTableCmd.CommandText = "DROP TABLE IF EXISTS Task";
-		await dropTableCmd.ExecuteNonQueryAsync();
-		_hasBeenInitialized = false;
+			var dropTableCmd = connection.CreateCommand();
+			dropTableCmd.CommandText = "DROP TABLE IF EXISTS Task";
+			await dropTableCmd.ExecuteNonQueryAsync();
+
+			_hasBeenInitialized = false;
+		}
+		finally
+		{
+			_initLock.Release();
+		}
 	}
 }

--- a/9.0/Apps/DeveloperBalance/Models/ProjectsTags.cs
+++ b/9.0/Apps/DeveloperBalance/Models/ProjectsTags.cs
@@ -1,8 +1,0 @@
-namespace DeveloperBalance.Models;
-
-public class ProjectsTags
-{
-	public int ID { get; set; }
-	public int ProjectID { get; set; }
-	public int TagID { get; set; }
-}

--- a/9.0/Apps/DeveloperBalance/PageModels/MainPageModel.cs
+++ b/9.0/Apps/DeveloperBalance/PageModels/MainPageModel.cs
@@ -152,8 +152,8 @@ public partial class MainPageModel : ObservableObject, IProjectTaskPageModel
 		=> Shell.Current.GoToAsync($"task");
 
 	[RelayCommand]
-	private Task? NavigateToProject(Project project)
-		=> project is null ? null : Shell.Current.GoToAsync($"project?id={project.ID}");
+	private Task NavigateToProject(Project project)
+		=> project is null ? Task.CompletedTask : Shell.Current.GoToAsync($"project?id={project.ID}");
 
 	[RelayCommand]
 	private Task NavigateToTask(ProjectTask task)

--- a/9.0/Apps/DeveloperBalance/PageModels/ProjectListPageModel.cs
+++ b/9.0/Apps/DeveloperBalance/PageModels/ProjectListPageModel.cs
@@ -28,8 +28,8 @@ public partial class ProjectListPageModel : ObservableObject
 	}
 
 	[RelayCommand]
-	Task? NavigateToProject(Project project)
-		=> project is null ? null : Shell.Current.GoToAsync($"project?id={project.ID}");
+	private Task NavigateToProject(Project project)
+		=> project is null ? Task.CompletedTask : Shell.Current.GoToAsync($"project?id={project.ID}");
 
 	[RelayCommand]
 	async Task AddProject()

--- a/9.0/Apps/DeveloperBalance/Platforms/Android/MainActivity.cs
+++ b/9.0/Apps/DeveloperBalance/Platforms/Android/MainActivity.cs
@@ -7,4 +7,24 @@ namespace DeveloperBalance;
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    public override void OnBackPressed()
+    {
+        // Workaround for a .NET MAUI 9 bug where pressing Back from a root Shell page
+        // destroys the Activity. On relaunch, CollectionView adapters still reference
+        // the destroyed Activity context and attempt to load FontImageSource icons via
+        // Glide, causing:
+        //   java.lang.IllegalArgumentException: You cannot start a load for a destroyed activity
+        //
+        // Fix: when at the root of the navigation stack, move the app to the background
+        // instead of finishing the Activity, preventing Activity destruction.
+        // This is fixed in .NET 10: https://github.com/dotnet/maui/issues/29699
+        var navStack = Shell.Current?.Navigation?.NavigationStack;
+        if (navStack is null || navStack.Count <= 1)
+        {
+            MoveTaskToBack(true);
+            return;
+        }
+
+        base.OnBackPressed();
+    }
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request introduces several important improvements to the data access layer and UI navigation logic of the DeveloperBalance application. The main focus is on making database initialization and table management thread-safe, optimizing queries to reduce database load, and improving code consistency and safety in navigation commands.

**Description of Change**

* Updated `ClearTables()` from `async void` to `async Task` and ensured it is properly awaited in `LoadSeedDataAsync()` to maintain correct execution order during seed initialization.

* Modified table drop logic in `SeedDataService.ClearTables()` to execute sequentially instead of using `Task.WhenAll()`. Now only `_projectRepository.DropTableAsync()` and `_categoryRepository.DropTableAsync()` are called, ensuring dependent tables are dropped exactly once.

* Renamed incorrectly named file `TaskRespository.cs` to `TaskRepository.cs` to align with class naming and maintain repository naming consistency.

* Introduced `SemaphoreSlim _initLock` in all repositories and implemented a double-check locking pattern in `Init()` to ensure thread-safe initialization. Updated `DropTableAsync()` methods to execute under the same lock to prevent concurrent reset conditions.

* Optimized `ProjectRepository.ListAsync()` by replacing per-project queries with bulk retrieval of tasks and tags, followed by in-memory grouping and assignment to projects.

* Removed unused `ProjectsTags` model class (`Models/ProjectsTags.cs`) that was not referenced anywhere in the codebase.

* Corrected SQL parameter usage in `TagRepository.ListAsync(int projectID)` by adding the missing `@` prefix to `ProjectID`.

* Updated `NavigateToProject` to return `Task.CompletedTask` when the project is `null`, ensuring consistent asynchronous behavior.

* Added missing namespace declaration (`namespace DeveloperBalance.Data;`) to `JsonContext.cs` to align with project structure and maintain consistency.

* Updated `DisplaySnackbarAsync` and `DisplayToastAsync` to use `using var` with `CancellationTokenSource`, ensuring proper disposal of resources.

These changes collectively make the application more robust, efficient, and maintainable.

**Issue Fixes**
Fixes #748 