### PR TITLE
Add 11.0 folder with global.json for .NET 11 previews

### DIFF
--- a/11.0/global.json
+++ b/11.0/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.2.26159.112",
+    "version": "11.0.100-preview.3.26207.106",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   }

--- a/11.0/global.json
+++ b/11.0/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "11.0.100-preview.2.26159.112",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
Adds the `11.0` sample folder (matching the existing `9.0` and `10.0` structure) with a `global.json` targeting the .NET 11 preview 3 SDK (`11.0.100-preview.3.26207.106`).

Uses `rollForward: latestFeature` and `allowPrerelease: true` so it will automatically pick up newer preview builds.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>