### PR TITLE
Add Directory.Build.props for centralized .NET 11 version management

### DIFF
--- a/11.0/Directory.Build.props
+++ b/11.0/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <!-- .NET MAUI 11 Preview 3 versions — update these when a new preview drops -->
+    <MauiVersion>11.0.0-preview.3.26203.7</MauiVersion>
+    <DotNetVersion>11.0.0-preview.3.26207.106</DotNetVersion>
+
+    <!-- Preview SDK may require a newer Xcode than currently available -->
+    <ValidateXcodeVersion>false</ValidateXcodeVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

Adds a `Directory.Build.props` at the `11.0/` root to centralize version management for all .NET MAUI 11 samples.

### Properties defined

| Property | Value | Usage |
|----------|-------|-------|
| `MauiVersion` | `11.0.0-preview.3.26203.7` | `Microsoft.Maui.Controls` package version |
| `DotNetVersion` | `11.0.0-preview.3.26207.106` | `Microsoft.Extensions.*` package versions |
| `ValidateXcodeVersion` | `false` | Required for preview SDK compatibility |

### How to use in sample .csproj files

```xml
<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(DotNetVersion)" />
```

No need to set `ValidateXcodeVersion` per  it's inherited automatically.project 

### Follow-up

Once merged, PRs #743 and #752 should be updated to use `$(MauiVersion)` / `$(DotNetVersion)` instead of hardcoded versions, and remove per-project `ValidateXcodeVersion` settings.