### PR TITLE
Add workload update to CI to fix .NET 11 preview manifest resolution

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Install .NET MAUI Workload
       run: |
-        dotnet workload update
+        dotnet workload config --update-mode manifests
         dotnet workload install maui
 
     - name: Select Xcode Version

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -27,7 +27,9 @@ jobs:
         dotnet-quality: 'preview'
 
     - name: Install .NET MAUI Workload
-      run: dotnet workload install maui
+      run: |
+        dotnet workload update
+        dotnet workload install maui
 
     - name: Select Xcode Version
       run: sudo xcode-select -s /Applications/Xcode_26.2.app

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,7 +31,9 @@ jobs:
         dotnet-quality: 'preview'
 
     - name: Install .NET MAUI Workload
-      run: dotnet workload install maui
+      run: |
+        dotnet workload update
+        dotnet workload install maui
 
     - name: Select Xcode Version
       run: sudo xcode-select -s /Applications/Xcode_26.2.app

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install .NET MAUI Workload
       run: |
-        dotnet workload update
+        dotnet workload config --update-mode manifests
         dotnet workload install maui
 
     - name: Select Xcode Version


### PR DESCRIPTION
## Problem

The .NET 11 preview 3 SDK ships with stale **preview 1** baseline workload manifests. When CI runs `dotnet workload install maui`, it finds "No workload update" and tries to install packs using the embedded preview 1  which don't exist on NuGet.versions 

## Fix

Add `dotnet workload update` before `dotnet workload install maui` in both `build-pr.yml` and `build-all.yml`. This forces the SDK to pull the latest manifest versions from NuGet before installing.

## Changes

- `.github/workflows/build-pr.yml`: Added `dotnet workload update`
- `.github/workflows/build-all.yml`: Added `dotnet workload update`

This unblocks CI for PRs #743, #752, and #753 (all .NET 11 samples).