### PR TITLE
Update CI to use Xcode 26.3

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -32,7 +32,7 @@ jobs:
         dotnet workload install maui
 
     - name: Select Xcode Version
-      run: sudo xcode-select -s /Applications/Xcode_26.2.app
+      run: sudo xcode-select -s /Applications/Xcode_26.3.app
       if: runner.os == 'macOS'
 
     - name: Find and build all C# projects

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -36,7 +36,7 @@ jobs:
         dotnet workload install maui
 
     - name: Select Xcode Version
-      run: sudo xcode-select -s /Applications/Xcode_26.2.app
+      run: sudo xcode-select -s /Applications/Xcode_26.3.app
       if: runner.os == 'macOS'
 
     - name: Find and build changed projects


### PR DESCRIPTION
## Problem

The latest .NET 10 iOS/MacCatalyst SDK workload (`26.2.10233`) now requires Xcode 26.3. CI currently selects Xcode 26.2, causing all macOS builds for .NET 10 projects to fail with:

```
error : This version of .NET for iOS (26.2.10233) requires Xcode 26.3. The current version of Xcode is 26.2.
```

## Fix

Update `xcode-select` from `Xcode_26.2.app` to `Xcode_26.3.app` in both workflow files.

## Changes

- `.github/workflows/build-pr.yml`
- `.github/workflows/build-all.yml`