### PR TITLE
Remove ValidateXcodeVersion workaround for .NET 11 samples

### DIFF
--- a/11.0/Directory.Build.props
+++ b/11.0/Directory.Build.props
@@ -3,8 +3,5 @@
     <!-- .NET MAUI 11 Preview 3 versions — update these when a new preview drops -->
     <MauiVersion>11.0.0-preview.3.26203.7</MauiVersion>
     <DotNetVersion>11.0.0-preview.3.26207.106</DotNetVersion>
-
-    <!-- Preview SDK may require a newer Xcode than currently available -->
-    <ValidateXcodeVersion>false</ValidateXcodeVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Removes `<ValidateXcodeVersion>false</ValidateXcodeVersion>` from `11.0/Directory.Build.props`.

This was added as a workaround when CI used Xcode 26.2 but the .NET 11 preview 3 SDK required 26.3. Now that CI uses Xcode 26.3 (#757), the workaround is no longer needed.