### PR TITLE
Fix broken screenshots on MS Learn for Material3 sample

### DIFF
--- a/10.0/UserInterface/Material3Demo/HealthProfile/README.md
+++ b/10.0/UserInterface/Material3Demo/HealthProfile/README.md
@@ -14,7 +14,7 @@ urlFragment: userinterface-material3
 
 | Material3 Light Theme Output | Material3 Dark Theme Output |
 | --- | --- |
-| <img width="320" alt="Material3 light theme output" src="Screenshots/LightTheme.png"> | <img width="320" alt="Material3 dark theme output" src="Screenshots/DarkTheme.png"> |
+| ![Material3 light theme output](Screenshots/LightTheme.png) | ![Material3 dark theme output](Screenshots/DarkTheme.png) |
 
 .NET Multi-platform App UI (.NET MAUI) apps can enable Material 3 styling on Android by setting the `UseMaterial3` build property to `true` in the project file.
 


### PR DESCRIPTION
## Problem

The Material3 sample README uses HTML `<img>` tags for screenshots. MS Learn's sample browser only rewrites **Markdown image syntax** (`![alt](path)`) to serve from its media  HTML `<img>` tags are passed through with relative paths that don't resolve.CDN 

Result: https://learn.microsoft.com/en-us/samples/dotnet/maui-samples/userinterface-material3/ shows broken images.

## Fix

Convert HTML `<img>` tags to standard Markdown image syntax:

```markdown
```

This matches the pattern used by all other working samples (e.g., TabbedPageSVGIcons, ContextMenu, etc.).