### PR TITLE
Update SurfaceLight and OnSurfaceDark in Colors.xaml to Align with Material 3 Baseline

### DIFF
--- a/10.0/UserInterface/Material3Demo/HealthProfile/HealthProfile/Resources/Styles/Colors.xaml
+++ b/10.0/UserInterface/Material3Demo/HealthProfile/HealthProfile/Resources/Styles/Colors.xaml
@@ -36,7 +36,7 @@
     <Color x:Key="TertiaryContainerDark">#633B48</Color>
     <Color x:Key="OnTertiaryContainerDark">#FFD8E4</Color>
 
-    <Color x:Key="SurfaceLight">#FFFBFE</Color>
+    <Color x:Key="SurfaceLight">#FEF7FF</Color>
     <Color x:Key="SurfaceContainerLight">#F3EDF7</Color>
     <Color x:Key="SurfaceVariantLight">#E7E0EC</Color>
     <Color x:Key="OnSurfaceLight">#1D1B20</Color>

--- a/10.0/UserInterface/Material3Demo/HealthProfile/HealthProfile/Resources/Styles/Colors.xaml
+++ b/10.0/UserInterface/Material3Demo/HealthProfile/HealthProfile/Resources/Styles/Colors.xaml
@@ -47,7 +47,7 @@
     <Color x:Key="SurfaceDark">#141218</Color>
     <Color x:Key="SurfaceContainerDark">#211F26</Color>
     <Color x:Key="SurfaceVariantDark">#49454F</Color>
-    <Color x:Key="OnSurfaceDark">#E6E1E5</Color>
+    <Color x:Key="OnSurfaceDark">#E6E0E9</Color>
     <Color x:Key="OnSurfaceVariantDark">#CAC4D0</Color>
     <Color x:Key="OutlineDark">#938F99</Color>
     <Color x:Key="OutlineVariantDark">#49454F</Color>


### PR DESCRIPTION

### Description of Changes

This pull request makes minor adjustments to the color palette in the `Colors.xaml` resource file. The changes update the hex values for the `SurfaceLight` and `OnSurfaceDark` colors to better align with Material Design 3 specifications.

Color palette updates:

* Updated the `SurfaceLight` color value from `#FFFBFE` to `#FEF7FF` for improved consistency with Material 3 guidelines.
* Updated the `OnSurfaceDark` color value from `#E6E1E5` to `#E6E0E9` for better visual accuracy in dark mode.

### Output
| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/9f885bab-c200-4ce9-b4a2-269dc1ddec29"> | <img src="https://github.com/user-attachments/assets/81242e9e-6898-4825-a2ec-e88c39719fc3"> |