### PR TITLE
Update .NET 11 samples to Preview 7

### DIFF
--- a/11.0/Directory.Build.props
+++ b/11.0/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <!-- .NET MAUI 11 Preview 3 versions — update these when a new preview drops -->
-    <MauiVersion>11.0.0-preview.3.26203.7</MauiVersion>
-    <DotNetVersion>11.0.0-preview.3.26207.106</DotNetVersion>
+    <!-- .NET MAUI 11 Preview 7 versions — update these when a new preview drops -->
+    <MauiVersion>11.0.0-preview.7.26404.4</MauiVersion>
+    <DotNetVersion>11.0.0-preview.7.26381.103</DotNetVersion>
   </PropertyGroup>
 </Project>

--- a/11.0/Directory.Build.props
+++ b/11.0/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- .NET MAUI 11 Preview 7 versions — update these when a new preview drops -->
-    <MauiVersion>11.0.0-preview.7.26404.4</MauiVersion>
+    <MauiVersion>11.0.0-preview.7.26406.9</MauiVersion>
     <DotNetVersion>11.0.0-preview.7.26381.103</DotNetVersion>
   </PropertyGroup>
 </Project>

--- a/11.0/README.md
+++ b/11.0/README.md
@@ -10,7 +10,7 @@ This folder contains samples that demonstrate **features specific to .NET MAUI 1
 
 ```bash
 # 1. Install the preview SDK locally (does NOT modify your system PATH)
-./dotnet-install.sh --version 11.0.100-preview.3.26207.106 --install-dir ./.dotnet
+./dotnet-install.sh --version 11.0.100-preview.7.26381.103 --install-dir ./.dotnet
 
 # 2. The global.json in this folder already has sdk.paths configured:
 cat global.json
@@ -21,7 +21,7 @@ The `global.json` in this folder uses `sdk.paths` to point to a local `.dotnet/`
 ```json
 {
   "sdk": {
-    "version": "11.0.100-preview.3.26207.106",
+    "version": "11.0.100-preview.7.26381.103",
     "paths": [".dotnet"]
   }
 }

--- a/11.0/global.json
+++ b/11.0/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.3.26207.106",
+    "version": "11.0.100-preview.7.26381.103",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   }


### PR DESCRIPTION
## Summary
- update the repo-local .NET 11 SDK baseline to `11.0.100-preview.7.26381.103`
- update centralized .NET packages to `11.0.0-preview.7.26381.103` and MAUI to `11.0.0-preview.7.26406.9`
- refresh the Preview 7 installation guidance

## Validation
- verified the SDK artifact from official Preview 7 build metadata
- verified the final MAUI workload manifest and packages on the official `dotnet11` feed
- parsed `global.json` and `Directory.Build.props`
- macOS and Windows CI passed
- staged factual/code review was clean

## Release status
The final Preview 7 SDK and MAUI artifacts are available on the official `dotnet11` feed, and this PR's macOS and Windows CI checks are green. This baseline is ready for review and merge.

NuGet.org has not published MAUI `11.0.0-preview.7.26406.9` yet. That publication remains a blocker for dependent sample PRs #776 and #777.

Markdown lint still reports the same pre-existing line-length/list-spacing findings in `11.0/README.md`; this change does not introduce them.