### PR TITLE
Pin .NET 11 Preview 7 SDK in PR CI

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         dotnet-version: |
           10.0.x
-          11.0.x
+          11.0.100-preview.7.26381.103
         include-prerelease: true
         dotnet-quality: 'preview'
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         dotnet-version: |
           10.0.x
-          11.0.100-preview.7.26381.103
+          11.0.x
         include-prerelease: true
         dotnet-quality: 'preview'
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         dotnet-version: |
           10.0.x
-          11.0.x
+          11.0.100-preview.7.26381.103
         include-prerelease: true
         dotnet-quality: 'preview'
 


### PR DESCRIPTION
## Description

Pin pull request CI to .NET SDK `11.0.100-preview.7.26381.103` instead of the floating `11.0.x` channel. This aligns workload installation with the Preview 7 baseline merged in #775.

The floating channel resolved SDK `11.0.100-preview.6.26359.118` and Preview 6 Android/MAUI workloads. Builds against the final Preview 7 MAUI packages then failed with `CS1705` because `Microsoft.Maui` uses `Java.Interop` 99.61 while the installed workload references version 10.

## Scope

- Keep `10.0.x` unchanged.
- Change only the .NET 11 SDK selector in `build-pr.yml`.
- Do not change sample code or other workflow logic.

## Validation

- Parsed `build-pr.yml` as YAML.
- Confirmed the final PR diff is one file with one insertion and one deletion.
- Confirmed setup-dotnet v4 supports exact prerelease SDK versions.
- Confirmed the official dotnet-install dry run resolves public payload URLs for the exact Preview 7 SDK.
- Completed pre-push review with no merge-blocking findings.