### PR TITLE
Use Xcode 26.6 in CI

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -31,7 +31,7 @@ jobs:
         dotnet workload install maui
 
     - name: Select Xcode Version
-      run: sudo xcode-select -s /Applications/Xcode_26.3.app
+      run: sudo xcode-select -s /Applications/Xcode_26.6.app
       if: runner.os == 'macOS'
 
     - name: Find and build all C# projects

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -35,7 +35,7 @@ jobs:
         dotnet workload install maui
 
     - name: Select Xcode Version
-      run: sudo xcode-select -s /Applications/Xcode_26.3.app
+      run: sudo xcode-select -s /Applications/Xcode_26.6.app
       if: runner.os == 'macOS'
 
     - name: Find and build changed projects


### PR DESCRIPTION
## Description

Select Xcode 26.6 in both MAUI sample build workflows. The final .NET 11 Preview 7 Apple packs require Xcode 26.6.

## Evidence

- Published `Microsoft.iOS.Sdk.net11.0_26.5` version `26.5.11997-net11-p7` sets `RecommendedXcodeVersion` to `26.6`.
- The `dotnet/macios` `release/11.0.1xx-preview7` branch sets `XCODE_VERSION=26.6`.
- The `macos-26` runner image lists Xcode 26.6 as the default at `/Applications/Xcode_26.6.app`.

## Scope

- Change only the existing `xcode-select` path in `build-pr.yml` and `build-all.yml`.
- Do not change SDK selection, workload installation, build logic, or sample code.

## Validation

- Parsed both workflows as YAML.
- Confirmed no workflow references `/Applications/Xcode_26.3.app`.
- Completed pre-push review with no findings.